### PR TITLE
States for apache-reload and apache-restart using module.wait not working

### DIFF
--- a/apache/debian_full.sls
+++ b/apache/debian_full.sls
@@ -17,7 +17,7 @@ a2dissite 000-default:
     - order: 225
     - onlyif: ls /etc/apache2/sites-enabled/000-default
     - watch_in:
-      - cmd: apache-reload
+      - module: apache-reload
     - require:
       - pkg: apache
 

--- a/apache/init.sls
+++ b/apache/init.sls
@@ -11,9 +11,10 @@ apache:
 
 apache-reload:
   module.wait:
-    - name: service.reload {{ apache.service }}
+    - name: service.reload
+    - m_name: {{ apache.service }}
 
 apache-restart:
   module.wait:
-    - name: service.restart {{ apache.service }}
-
+    - name: service.restart
+    - m_name: {{ apache.service }}

--- a/apache/register_site.sls
+++ b/apache/register_site.sls
@@ -39,7 +39,7 @@ a2dissite {{ pillar['apache']['register-site'][site]['name'] }}:
     - mode: 775
     - watch_in:
       - cmd: a2ensite {{ pillar['apache']['register-site'][site]['name'] }}
-      - cmd: apache-reload
+      - module: apache-reload
 
 {% endif %}
 ##########################################

--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -18,7 +18,7 @@ include:
     - require:
       - pkg: apache
     - watch_in:
-      - cmd: apache-reload
+      - module: apache-reload
 
 {% if grains.os_family == 'Debian' %}
 a2ensite {{ id }}:


### PR DESCRIPTION
Looks like a reminiscence after cmd.wait. 

Tested on:
- Oracle Linux 6.5 
- Salt 0.17.4.
