### PR TITLE
Fix link to instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Formulas to set up and configure the Apache HTTP server.
 .. note::
 
     See the full `Salt Formulas installation and usage instructions
-    <http://docs.saltstack.com/topics/conventions/formulas.html>`_.
+    <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
 Available states
 ================


### PR DESCRIPTION
The link to the installation and usage instructions does not work. This fixes it. If the URL should be different please correct.
