### PR TITLE
Adding support for Apache 2.4 on Ubuntu 14.04

### DIFF
--- a/apache/debian_full.sls
+++ b/apache/debian_full.sls
@@ -1,3 +1,5 @@
+{% from "apache/map.jinja" import apache with context %}
+
 {% if grains['os_family']=="Debian" %}
 
 include:
@@ -17,24 +19,21 @@ extend:
     module:
       - order: 425
 
-a2dissite 000-default:
+a2dissite 000-default{{ apache.confext }}:
   cmd.run:
-    - order: 225
-    - onlyif: ls /etc/apache2/sites-enabled/000-default
+    - onlyif: test -f /etc/apache2/sites-enabled/000-default{{ apache.confext }}
     - watch_in:
       - module: apache-reload
     - require:
       - pkg: apache
 
-/etc/apache2/sites-available/default:
+/etc/apache2/sites-available/{{ apache.default_site }}:
   file.absent:
-    - order: 230
     - require:
       - pkg: apache
 
-/etc/apache2/sites-available/default-ssl:
+/etc/apache2/sites-available/{{ apache.default_site_ssl }}:
   file.absent:
-    - order: 230
     - require:
       - pkg: apache
 

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -8,8 +8,11 @@
         'vhostdir': '/etc/apache2/sites-available',
         'confdir': '/etc/apache2/conf.d',
         'confext': '',
+        'default_site': 'default',
+        'default_site_ssl': 'default-ssl',
         'logdir': '/var/log/apache2',
         'wwwdir': '/srv',
+        'require_all': False,
     },
     'RedHat': {
         'server': 'httpd',
@@ -20,8 +23,11 @@
         'vhostdir': '/etc/httpd/conf.d',
         'confdir': '/etc/httpd/conf.d',
         'confext': '.conf',
+        'default_site': 'default',
+        'default_site_ssl': 'default-ssl',
         'logdir': '/var/log/httpd',
         'wwwdir': '/var/www',
+        'require_all': False,
     },
     'FreeBSD': {
         'server': 'apache22',
@@ -32,7 +38,19 @@
         'vhostdir': '/usr/local/etc/apache22/Includes',
         'confdir': '/usr/local/etc/apache22/Includes',
         'confext': '',
+        'default_site': 'default',
+        'default_site_ssl': 'default-ssl',
         'logdir': '/var/log/',
         'wwwdir': '/usr/local/www/apache22/',
+        'require_all': False,
     },
-}, merge=salt['pillar.get']('apache:lookup')) %}
+}, merge=salt['grains.filter_by']({
+    '14.04': {
+        'confext': '.conf',
+        'default_site': '000-default.conf',
+        'default_site_ssl': 'default-ssl.conf',
+        'require_all': True,
+    },
+}, grain='lsb_distrib_release', merge=salt['pillar.get']('apache:lookup'))) %}
+
+

--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -1,5 +1,7 @@
 {# Define default values here so the template below can just focus on layout #}
+{% from "apache/map.jinja" import apache with context %}
 {% set sitename = site.get('ServerName', id) %}
+
 {% set vals = {
     'interface': site.get('interface', '*'),
     'port': site.get('port', '80'),
@@ -45,11 +47,20 @@
     {% if site.get('DocumentRoot') != False %}DocumentRoot {{ vals.DocumentRoot }}{% endif %}
     {% if site.get('VirtualDocumentRoot') %}VirtualDocumentRoot {{ vals.VirtualDocumentRoot }}{% endif %}
 
+    {% if site.get('DocumentRoot') != False %}
+    <Directory {{ vals.DocumentRoot }}>
+       {% if apache.require_all %}
+          Require all granted
+       {% endif %}
+    </Directory>
+    {% endif %}
+
     {% for path, dir in site.get('Directory', {}).items() %}
     {% set dvals = {
         'Options': dir.get('Options', vals.Directory.Options),
         'Order': dir.get('Order', vals.Directory.Order),
         'Allow': dir.get('Allow', vals.Directory.Allow),
+        'Require': dir.get('Require', vals.Directory.Require),
         'AllowOverride': dir.get('AllowOverride', vals.Directory.AllowOverride),
     } %}
 
@@ -60,6 +71,7 @@
         {% if dir.get('Order') != False %}Order {{ dvals.Order }}{% endif %}
         {% if dir.get('Allow') != False %}Allow {{ dvals.Allow }}{% endif %}
         {% if dir.get('AllowOverride') != False %}AllowOverride {{ dvals.AllowOverride }}{% endif %}
+        {% if dir.get('Require') != False %}Require {{dvals.Require}}{% endif %}
 
         {% if dir.get('Formula_Append') %}
         {{ dir.Formula_Append|indent(8) }}

--- a/pillar.example
+++ b/pillar.example
@@ -49,8 +49,9 @@ apache:
         # E.g.: /var/www/example.com
         default:
           Options: -Indexes FollowSymLinks
-          Order: allow,deny
-          Allow: from all
+          Order: allow,deny    # For Apache < 2.4
+          Allow: from all      # For apache < 2.4
+          Require: all granted # For apache > 2.4.
           AllowOverride: None
           Formula_Append: |
             Additional config as a


### PR DESCRIPTION
- Adding confext to virtualhost names.
- Renaming the default config file for Ubuntu (000-default.conf).
- Adding ability to use "Require all granted".

This is my first PR for saltstack related things and being a non-Python programmer myself, I very much welcome any critique on anything I might have done wrong / that might be improved upon.
