### PR TITLE
Add ability to specify modules in pillar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,11 @@ Available states
 
 Installs the Apache package and starts the service.
 
+``apache.modules``
+------------------
+
+Enables and disables Apache modules.
+
 ``apache.mod_proxy``
 -------------------
 

--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -1,0 +1,28 @@
+{% if grains['os_family']=="Debian" %}
+
+include:
+  - apache
+
+{% for module in salt['pillar.get']('apache:modules:enabled', []) %}
+a2enmod {{ module }}:
+  cmd.run:
+    - unless: ls /etc/apache2/mods-enabled/{{ module }}.load
+    - order: 225
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+{% endfor %}
+
+{% for module in salt['pillar.get']('apache:modules:disabled', []) %}
+a2dismod {{ module }}:
+  cmd.run:
+    - onlyif: ls /etc/apache2/mods-enabled/{{ module }}.load
+    - order: 225
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+{% endfor %}
+
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -68,3 +68,10 @@ apache:
       name: 'my name'
       path: 'salt://path/to/sites-available/conf/file'
       state: 'enabled'
+
+  modules:
+    enabled:  # List modules to enable
+      - ldap
+      - ssl
+    disabled:  # List modules to disable
+      - rewrite


### PR DESCRIPTION
This should close #30. This state will not work for modules that need to be installed. The states for proxy and proxy_http are made obsolete by this change. I left them for backwards compatibility for now.
