### PR TITLE
Fix mod-php5 dependency when setting php.ini

### DIFF
--- a/apache/php5.sls
+++ b/apache/php5.sls
@@ -28,7 +28,7 @@ a2enmod php5:
       - module: apache-restart
     - require:
       - pkg: apache
-      - pkg: php5
+      - pkg: mod-php5
 {% endif %}
 
 {% endif %}


### PR DESCRIPTION
I think the pkg requirement is wrong, updated to mod-php5
