### PR TITLE
Ensure DocumentRoot is present

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -20,7 +20,7 @@ include:
     - watch_in:
       - module: apache-reload
 
-document_root:
+document_root_{{ id }}:
   file:
     - directory
     - name: {{ site.get('DocumentRoot', '{0}/{1}'.format(apache.wwwdir, id)) }}

--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -20,6 +20,15 @@ include:
     - watch_in:
       - module: apache-reload
 
+document_root:
+  file:
+    - directory
+    - name: {{ site.get('DocumentRoot', '{0}/{1}'.format(apache.wwwdir, id)) }}
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-reload
+
 {% if grains.os_family == 'Debian' %}
 a2ensite {{ id }}{{ apache.confext }}:
   cmd:

--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -39,13 +39,17 @@
     {% if site.get('ServerAdmin') != False %}ServerAdmin {{ vals.ServerAdmin }}{% endif %}
 
     {% if site.get('DirectoryIndex') %}DirectoryIndex {{ vals.DirectoryIndex }}{% endif %}
+
     {% if site.get('UseCanonicalName') %}UseCanonicalName {{ vals.UseCanonicalName }}{% endif %}
 
     {% if site.get('LogLevel') != False %}LogLevel {{ vals.LogLevel }}{% endif %}
+
     {% if site.get('ErrorLog') != False %}ErrorLog {{ vals.ErrorLog }}{% endif %}
+
     {% if site.get('CustomLog') != False %}CustomLog {{ vals.CustomLog }} {{ vals.LogFormat }}{% endif %}
 
     {% if site.get('DocumentRoot') != False %}DocumentRoot {{ vals.DocumentRoot }}{% endif %}
+
     {% if site.get('VirtualDocumentRoot') %}VirtualDocumentRoot {{ vals.VirtualDocumentRoot }}{% endif %}
 
     {% for path, dir in site.get('Directory', {}).items() %}
@@ -61,21 +65,29 @@
 
     <Directory "{{ path }}">
         {% if dir.get('Options') != False %}Options {{ dvals.Options }}{% endif %}
+
         {% if apache.use_require %}
+
         {% if dir.get('Require') != False %}Require {{dvals.Require}}{% endif %}
         {% else %}
+
         {% if dir.get('Order') != False %}Order {{ dvals.Order }}{% endif %}
+
         {% if dir.get('Allow') != False %}Allow {{ dvals.Allow }}{% endif %}
         {% endif %}
+
         {% if dir.get('AllowOverride') != False %}AllowOverride {{ dvals.AllowOverride }}{% endif %}
 
         {% if dir.get('Formula_Append') %}
+
         {{ dir.Formula_Append|indent(8) }}
         {% endif %}
+
     </Directory>
     {% endfor %}
 
     {% if site.get('Formula_Append') %}
     {{ site.Formula_Append|indent(4) }}
     {% endif %}
+
 </VirtualHost>

--- a/pillar.example
+++ b/pillar.example
@@ -1,16 +1,17 @@
 # ``apache`` formula configuration:
 apache:
-  server: apache2
-  service: apache2
+  lookup:
+    server: apache2
+    service: apache2
 
-  vhostdir: /etc/apache2/sites-available
-  confdir: /etc/apache2/conf.d
-  confext: .conf
-  logdir: /var/log/apache2
-  wwwdir: /srv/apache2
+    vhostdir: /etc/apache2/sites-available
+    confdir: /etc/apache2/conf.d
+    confext: .conf
+    logdir: /var/log/apache2
+    wwwdir: /srv/apache2
 
-  # ``apache.mod_wsgi`` formula additional configuration:
-  mod_wsgi: mod_wsgi
+    # ``apache.mod_wsgi`` formula additional configuration:
+    mod_wsgi: mod_wsgi
 
   # ``apache.vhosts`` formula additional configuration:
   sites:


### PR DESCRIPTION
Make sure that the DocumentRoot is present while configuring a vhost.
If not present, the apache-reload will throw a warning.