### PR TITLE
Fix case where state != enabled causes error

### DIFF
--- a/apache/register_site.sls
+++ b/apache/register_site.sls
@@ -8,10 +8,11 @@
 {% if 'name' in pillar['apache']['register-site'][site] and 'state' in pillar['apache']['register-site'][site] %}
 
 {% if pillar['apache']['register-site'][site]['state'] == 'enabled' %}
-a2ensite {{ pillar['apache']['register-site'][site]['name'] }}:
+{% set a2modid = "a2ensite " ~ pillar['apache']['register-site'][site]['name'] %}
 {% else %}
-a2dissite {{ pillar['apache']['register-site'][site]['name'] }}:
+{% set a2modid = "a2dissite " ~ pillar['apache']['register-site'][site]['name'] %}
 {% endif %}
+{{ a2modid }}:
   cmd.run:
 {% if pillar['apache']['register-site'][site]['state'] == 'enabled' %}
     - unless: test -f /etc/apache2/sites-enabled/{{ pillar['apache']['register-site'][site]['name'] }}
@@ -38,7 +39,7 @@ a2dissite {{ pillar['apache']['register-site'][site]['name'] }}:
     - group: root
     - mode: 775
     - watch_in:
-      - cmd: a2ensite {{ pillar['apache']['register-site'][site]['name'] }}
+      - cmd: {{ a2modid }}
       - module: apache-reload
 
 {% endif %}


### PR DESCRIPTION
When using the register_site state, if the `state` for the
site in the apache pillar did not equal "enabled" the error

```
Cannot extend ID 'a2ensite <name>' in 'base:apache.register_site'. It is not part of the high state.
```

If statements were there to build out the `a2ensite` or `a2dissite` ID
appropiately, but the next state for managing the config always
assumed that the `a2ensite` id would be there.

Addressed by making a Jinja variable that will be the appropiate ID,
probably could use a better name.