### PR TITLE
Add optional templating to register_site files

### DIFF
--- a/apache/register_site.sls
+++ b/apache/register_site.sls
@@ -38,6 +38,13 @@
     - user: root
     - group: root
     - mode: 775
+{% if 'template' in pillar['apache']['register-site'][site] and 'defaults' in pillar['apache']['register-site'][site] %}
+    - template: jinja
+    - defaults:
+    {% for key, value in pillar['apache']['register-site'][site]['defaults'].iteritems() %}
+      {{ key }}: {{ value }}
+    {% endfor %}
+{% endif %}
     - watch_in:
       - cmd: {{ a2modid }}
       - module: apache-reload

--- a/pillar.example
+++ b/pillar.example
@@ -81,6 +81,10 @@ apache:
       name: 'my name'
       path: 'salt://path/to/sites-available/conf/file'
       state: 'enabled'
+      # Optional - use managed file as Jinja Template
+      #template: true
+      #defaults:
+      #  custom_var: "default value"
 
   modules:
     enabled:  # List modules to enable


### PR DESCRIPTION
Add optional templating for the register site aspect of the formula.

User can specify keys to be included as defaults, otherwise it is
treated as a normal managed file.