### PR TITLE
Create vhost DocumentRoot directory

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -19,6 +19,11 @@ include:
       - pkg: apache
     - watch_in:
       - module: apache-reload
+      
+{{ id }}-documentroot:
+  file.directory:
+    - unless: test -d {{ site.get('DocumentRoot') }}
+    - name: {{ site.get('DocumentRoot') }}
 
 {% if grains.os_family == 'Debian' %}
 a2ensite {{ id }}{{ apache.confext }}:


### PR DESCRIPTION
If a vhost is defined in the pillar, create the DocumentRoot directory if it doesn't already exist.