### PR TITLE
make modules.sls compatible with RHEL/CentOS Apache 2.2

### DIFF
--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -26,3 +26,32 @@ a2dismod {{ module }}:
 {% endfor %}
 
 {% endif %}
+
+{% if grains['os_family']=="RedHat" %}
+
+include:
+  - apache
+ 
+{% for module in salt['pillar.get']('apache:modules:enabled', []) %}
+find /etc/httpd/ -name *.conf -type f -exec sed -i -e 's/\(^#\)\(LoadModule.{{ module }}_module\)/\2/g' {} \;:
+  cmd.run:
+    - unless: httpd -M 2> /dev/null | grep {{ module }}_module
+    - order: 225
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+{% endfor %}
+
+{% for module in salt['pillar.get']('apache:modules:disabled', []) %}
+find /etc/httpd/ -name *.conf -type f -exec sed -i -e 's/\(^LoadModule.{{ module }}_module\)/#\1/g' {} \;:
+  cmd.run:
+    - onlyif: httpd -M 2> /dev/null | grep {{ module }}_module
+    - order: 225
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+{% endfor %}
+
+{% endif %}

--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -25,9 +25,7 @@ a2dismod {{ module }}:
       - module: apache-restart
 {% endfor %}
 
-{% endif %}
-
-{% if grains['os_family']=="RedHat" %}
+{% elif grains['os_family']=="RedHat" %}
 
 include:
   - apache


### PR DESCRIPTION
I discovered that formula apache.modules only works with os_family Debian. I'm on RHEL/CentOS so I took a stab at adding functionality for RedHat. 

This is my first YAML/jinja/salt thing I have ever done so look at it with a critical eye please!