### PR TITLE
Fix Jinja's reverse

### DIFF
--- a/apache/vhosts/proxy.tmpl
+++ b/apache/vhosts/proxy.tmpl
@@ -35,7 +35,7 @@
     {% if site.get('CustomLog') != False %}CustomLog {{ vals.CustomLog }} {{ vals.LogFormat }}{% endif %}
 
     ProxyPreserveHost {{ vals.ProxyPreserveHost }}    
-    {% for proxy, proxyargs in reverse(vals.ProxyRoute.items()) %}
+    {% for proxy, proxyargs in vals.ProxyRoute.items()|reverse %}
     {% set proxyvals = {
         'ProxyPassSource': proxyargs.get('ProxyPassSource', '/'),
         'ProxyPassTarget': proxyargs.get('ProxyPassTarget', 'https://{0}'.format(sitename)),

--- a/apache/vhosts/proxy.tmpl
+++ b/apache/vhosts/proxy.tmpl
@@ -35,7 +35,7 @@
     {% if site.get('CustomLog') != False %}CustomLog {{ vals.CustomLog }} {{ vals.LogFormat }}{% endif %}
 
     ProxyPreserveHost {{ vals.ProxyPreserveHost }}    
-    {% for proxy, proxyargs in vals.ProxyRoute.items()|reverse %}
+    {% for proxy, proxyargs in vals.ProxyRoute|dictsort|reverse %}
     {% set proxyvals = {
         'ProxyPassSource': proxyargs.get('ProxyPassSource', '/'),
         'ProxyPassTarget': proxyargs.get('ProxyPassTarget', 'https://{0}'.format(sitename)),


### PR DESCRIPTION
I got this error while using the ``proxy.tmpl`` template:

```
>>> import jinja2
>>> jinja2.Template('{{ reverse(foo) }}').render(foo='abcde')
...
UndefinedError: 'reverse' is undefined
>>> jinja2.Template('{{ foo|reverse }}').render(foo='abcde')
u'edcba'
```

Also, the second commit simplifies a bit and keeps the proxies order stable.