### PR TITLE
Don't fail on missing DocumentRoot

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -19,12 +19,14 @@ include:
       - pkg: apache
     - watch_in:
       - module: apache-reload
-      
+
+{% if 'DocumentRoot' in site %}
 {{ id }}-documentroot:
   file.directory:
     - unless: test -d {{ site.get('DocumentRoot') }}
     - name: {{ site.get('DocumentRoot') }}
     - makedirs: True
+{% endif %}
 
 {% if grains.os_family == 'Debian' %}
 a2ensite {{ id }}{{ apache.confext }}:


### PR DESCRIPTION
If the DocumentRoot value wasn't set, applying the state would cause the following error:

```
          ID: site.example.com-documentroot
    Function: file.directory
        Name: None
      Result: False
     Comment: Specified file None is not an absolute path
     Started: 15:07:05.596723
    Duration: 4.929 ms
     Changes:
```

This fixes the problem by not trying to check for the DocumentRoot directory is the value is missing.

Acutally, the DocumentRoot is recomputed in https://github.com/saltstack-formulas/apache-formula/blob/master/apache/vhosts/standard.tmpl#L22 but this occurs in the template and not in the .sls file.
A better fix would be to move this computation out of the template so the .sls file can also access it, but I'm not sure how to do that.