### PR TITLE
Set 'confext' for Debian systems.

### DIFF
--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -7,7 +7,7 @@
 
         'vhostdir': '/etc/apache2/sites-available',
         'confdir': '/etc/apache2/conf.d',
-        'confext': '',
+        'confext': '.conf',
         'default_site': 'default',
         'default_site_ssl': 'default-ssl',
         'logdir': '/var/log/apache2',


### PR DESCRIPTION
In #20, the author wasn't so sure about Debian systems.

On Debian, `.conf` is required as confext, otherwise tools like `a2ensite` etc. won't find their config files.