### PR TITLE
Fix SSL: incorrect syntax in pillar example and jinja template

### DIFF
--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -48,10 +48,10 @@
     {% if site.get('DocumentRoot') != False %}DocumentRoot {{ vals.DocumentRoot }}{% endif %}
     {% if site.get('VirtualDocumentRoot') %}VirtualDocumentRoot {{ vals.VirtualDocumentRoot }}{% endif %}
 
-    {% if site.get('SSLCertificateFile') != False %}
+    {% if site.get('SSLCertificateFile') %}
     SSLEngine on
     SSLCertificateFile {{ site.SSLCertificateFile }}
-    {%   if site.get('SSLCertificateKeyFile') != False %}
+    {%   if site.get('SSLCertificateKeyFile') %}
     SSLCertificateKeyFile {{ site.SSLCertificateKeyFile }}
     {%   endif %}
     {% endif %}

--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -48,10 +48,10 @@
     {% if site.get('DocumentRoot') != False %}DocumentRoot {{ vals.DocumentRoot }}{% endif %}
     {% if site.get('VirtualDocumentRoot') %}VirtualDocumentRoot {{ vals.VirtualDocumentRoot }}{% endif %}
 
-    {% if site.SSLCertificateFile is defined %}
+    {% if site.get('SSLCertificateFile') != False %}
     SSLEngine on
     SSLCertificateFile {{ site.SSLCertificateFile }}
-    {%   if site.SSLCertificateKeyFile is defined %}
+    {%   if site.get('SSLCertificateKeyFile') != False %}
     SSLCertificateKeyFile {{ site.SSLCertificateKeyFile }}
     {%   endif %}
     {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -44,8 +44,8 @@ apache:
 
       DocumentRoot: /path/to/www/dir/example.com # E.g., /var/www/example.com
 
-      SSLCertificateFile = /etc/ssl/mycert.pem # if ssl is desired
-      SSLCertificateKeyFile = /etc/ssl/mycert.pem.key # if key for cert is needed or in an extra file
+      SSLCertificateFile: /etc/ssl/mycert.pem # if ssl is desired
+      SSLCertificateKeyFile: /etc/ssl/mycert.pem.key # if key for cert is needed or in an extra file
 
       Directory:
         # "default" is a special case; Adds ``/path/to/www/dir/example.com``


### PR DESCRIPTION
The pillar example uses equals instead of colon for `SSLCertificateFile` and `SSLCertificateKey`.

Also, the syntax of the jinja template for the standard VirtualHost (`standard.tmpl`) did not correctly check for those pillar values. It was not using dict.get like other pillar values.