### PR TITLE
Create defaul vhost directories when DocumentRoot is not set

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Installs the mod_wsgi package and enables the Apache module.
 ``apache.vhosts.standard``
 -------------------------
 
-Configures Apache name-based virtual hosts using data from Pillar.
+Configures Apache name-based virtual hosts and creates virtual host directories using data from Pillar.
 
 Example Pillar:
 

--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -4,6 +4,7 @@ include:
   - apache
 
 {% for id, site in salt['pillar.get']('apache:sites', {}).items() %}
+{% set documentroot = site.get('DocumentRoot', '{0}/{1}'.format(apache.wwwdir, sitename)) %}
 
 {{ id }}:
   file:
@@ -20,13 +21,11 @@ include:
     - watch_in:
       - module: apache-reload
 
-{% if 'DocumentRoot' in site %}
 {{ id }}-documentroot:
   file.directory:
-    - unless: test -d {{ site.get('DocumentRoot') }}
-    - name: {{ site.get('DocumentRoot') }}
+    - unless: test -d {{ documentroot }}
+    - name: {{ documentroot }}
     - makedirs: True
-{% endif %}
 
 {% if grains.os_family == 'Debian' %}
 a2ensite {{ id }}{{ apache.confext }}:


### PR DESCRIPTION
/apache/vhosts/standard.tmpl line 22:
''DocumentRoot': site.get('DocumentRoot', '{0}/{1}'.format(map.wwwdir, sitename))

This same technique should be applied to for creating the default directory instead of an if statement.
If someone omits DocumentRoot in the pillar the site conf would still point to a default document root
but the document root folder would not be created.