### PR TITLE
Correct variable name

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -4,7 +4,7 @@ include:
   - apache
 
 {% for id, site in salt['pillar.get']('apache:sites', {}).items() %}
-{% set documentroot = site.get('DocumentRoot', '{0}/{1}'.format(apache.wwwdir, sitename)) %}
+{% set documentroot = site.get('DocumentRoot', '{0}/{1}'.format(apache.wwwdir, id)) %}
 
 {{ id }}:
   file:


### PR DESCRIPTION
Using `sitename` as the name of the variable here causes the following error:

````
    Data failed to compile:
----------
    Rendering SLS 'base:apache.vhosts.standard' failed: Jinja variable 'sitename' is undefined
````

This pull request changes the variable name to be `id` which contains the vhosts id.