### PR TITLE
Fixed missing : and uppercased D in debian

### DIFF
--- a/apache/config.sls
+++ b/apache/config.sls
@@ -15,10 +15,10 @@ include:
 
 {% if grains['os_family']=="Debian" %}
 /etc/apache2/envvars:
-  file.managed
+  file.managed:
     - template: jinja
     - source:
-      - salt://apache/files/debian/envvars.jinja
+      - salt://apache/files/Debian/envvars.jinja
     - require:
       - pkg: apache
     - watch_in:


### PR DESCRIPTION
There's a syntax error in the definition for `envvars` on Debian. Also the folder with the file is called `Debian`.