### PR TITLE
RedHat fixes: change default vhostdir to redhat official

### DIFF
--- a/apache/config.sls
+++ b/apache/config.sls
@@ -13,6 +13,13 @@ include:
     - watch_in:
       - service: apache
 
+{{ apache.vhostdir }}:
+  file.directory:
+    - require:
+      - pkg: apache
+    - watch_in:
+      - service: apache
+
 {% if grains['os_family']=="Debian" %}
 /etc/apache2/envvars:
   file.managed:

--- a/apache/files/RedHat/apache.config.jinja
+++ b/apache/files/RedHat/apache.config.jinja
@@ -354,3 +354,4 @@ EnableSendfile on
 #
 # Load config files in the "/etc/httpd/conf.d" directory, if any.
 IncludeOptional conf.d/*.conf
+IncludeOptional vhosts.d/*.conf

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -25,7 +25,7 @@
         'mod_wsgi': 'mod_wsgi',
         'mod_php5': 'php',
 
-        'vhostdir': '/etc/httpd/conf.d',
+        'vhostdir': '/etc/httpd/vhosts.d',
         'confdir': '/etc/httpd/conf.d',
         'confext': '.conf',
         'default_site': 'default',


### PR DESCRIPTION
Change default vhostdir to redhat official default /etc/httpd/vhosts.d. Add state for ensuring that vhostdir exists. Include vhosts.d/*.conf in httpd.conf.