### PR TITLE
fix apache-restart ID in apache/mod_mpm according to apache/init.sls

### DIFF
--- a/apache/mod_mpm.sls
+++ b/apache/mod_mpm.sls
@@ -11,7 +11,7 @@ a2enmod {{ mpm_module }}:
     - require:
       - pkg: apache
     - watch_in:
-      - module: apache_restart
+      - module: apache-restart
   file.managed:
     - name: /etc/apache2/mods-available/{{ mpm_module }}.conf
     - template: jinja
@@ -20,7 +20,7 @@ a2enmod {{ mpm_module }}:
     - require:
       - pkg: apache
     - watch_in:
-      - module: apache_restart
+      - module: apache-restart
 
 # Deactivate the other mpm modules as a previous step
 {% for mod in ['mpm_prefork', 'mpm_worker', 'mpm_event'] if not mod == mpm_module %}
@@ -32,7 +32,7 @@ a2dismod {{ mod }}:
     - require_in:
       - cmd: a2enmod {{ mpm_module }}
     - watch_in:
-      - module: apache_restart
+      - module: apache-restart
 {% endfor %}
 
 {% endif %}


### PR DESCRIPTION
This fixes the `apache/mod_mpm.sls` state, which was broken because of the usage of `apache_restart` ID, which doesn't exist anymore.
It has been changed to `apache-restart`, according to the ID in `apache/init.sls`
