### PR TITLE
add a boolean to a site configuration to enable or disable it

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -46,5 +46,6 @@ a2dissite {{ id }}{{ apache.confext }}:
     - watch_in:
       - module: apache-reload
 {% endif %}
+{% endif %}
 
 {% endfor %}

--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -28,10 +28,19 @@ include:
     - makedirs: True
 
 {% if grains.os_family == 'Debian' %}
+{% if site.get('enabled') %}
 a2ensite {{ id }}{{ apache.confext }}:
   cmd:
     - run
     - unless: test -f /etc/apache2/sites-enabled/{{ id }}{{ apache.confext }}
+    - require:
+      - file: /etc/apache2/sites-available/{{ id }}{{ apache.confext }}
+    - watch_in:
+      - module: apache-reload
+{% else %}
+a2dissite {{ id }}{{ apache.confext }}:
+  cmd:
+    - run
     - require:
       - file: /etc/apache2/sites-available/{{ id }}{{ apache.confext }}
     - watch_in:

--- a/pillar.example
+++ b/pillar.example
@@ -18,6 +18,7 @@ apache:
       template_file: salt://apache/vhosts/minimal.tmpl
 
     example.com: # must be unique; used as an ID declaration in Salt.
+      enabled: True
       template_file: salt://apache/vhosts/standard.tmpl # or redirect.tmpl or proxy.tmpl
 
       ####################### DEFAULT VALUES BELOW ############################


### PR DESCRIPTION
This introduces a new boolean attribute for a given site in the pillar : `enabled`
It will `a2ensite` or `a2dissite` the site according to the attribute's value.

This way you can for example disable sites that are enabled by default after the installation of apache :
~~~
apache:
   sites:
      000-default:
          enabled: False

     default-ssl:
         enabled: False
~~~