### PR TITLE
add lookup section to pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,16 +1,19 @@
 # ``apache`` formula configuration:
 apache:
-  server: apache2
-  service: apache2
 
-  vhostdir: /etc/apache2/sites-available
-  confdir: /etc/apache2/conf.d
-  confext: .conf
-  logdir: /var/log/apache2
-  wwwdir: /srv/apache2
+  # lookup section overrides ``map.jinja`` values
+  lookup:
+    server: apache2
+    service: apache2
 
-  # ``apache.mod_wsgi`` formula additional configuration:
-  mod_wsgi: mod_wsgi
+    vhostdir: /etc/apache2/sites-available
+    confdir: /etc/apache2/conf.d
+    confext: .conf
+    logdir: /var/log/apache2
+    wwwdir: /srv/apache2
+
+    # ``apache.mod_wsgi`` formula additional configuration:
+    mod_wsgi: mod_wsgi
 
   # ``apache.vhosts`` formula additional configuration:
   sites:


### PR DESCRIPTION
This is a proposed fix for #75 

This proposed fix assumes that we want to continue using "apache:lookup" in map.jinja.  

Note that apache:sites, apache:register-site, and apache:modules are NOT under apache:lookup as the respective state files currently access the pillar data directly rather than going through map.jinja.