### PR TITLE
Add apache version to pillar/map.jinja

### DIFF
--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -1,3 +1,5 @@
+{% import_yaml "apache/osfingermap.yaml" as osfingermap %}
+
 {% set apache = salt['grains.filter_by']({
     'Debian': {
         'server': 'apache2',
@@ -88,4 +90,7 @@
         'default_site_ssl': 'default-ssl.conf',
         'use_require': True,
     },
-}, grain='oscodename', merge=salt['pillar.get']('apache:lookup'))) %}
+}, grain='oscodename', merge=salt['grains.filter_by'](
+    osfingermap
+, grain='osfinger', merge=salt['pillar.get']('apache:lookup')))) %}
+

--- a/apache/osfingermap.yaml
+++ b/apache/osfingermap.yaml
@@ -1,0 +1,6 @@
+default:
+  version: '2.4'
+Red Hat Enterprise Linux Server-6:
+  version: '2.2'
+Red Hat Enterprise Linux Server-7:
+  version: '2.4'

--- a/pillar.example
+++ b/pillar.example
@@ -11,6 +11,9 @@ apache:
     confext: .conf
     logdir: /var/log/apache2
     wwwdir: /srv/apache2
+  
+    # apache version (generally '2.2' or '2.4')
+    version: '2.2'
 
     # ``apache.mod_wsgi`` formula additional configuration:
     mod_wsgi: mod_wsgi


### PR DESCRIPTION
Partially addresses #70 by adding apache version info to pillar/map.jinja

* Add apache version (2.2, 2.4) detection based on osfinger (defaults to 2.4).
* Version can be overridden in pillar (for Apache 2.4 on RHEL 6 for example)
* More distro version-->apache version mappings can be added over time to osfingermap.yaml