### PR TITLE
allow absence of DocumentRoot

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -21,11 +21,13 @@ include:
     - watch_in:
       - module: apache-reload
 
+{% if site.get('DocumentRoot') != False %}
 {{ id }}-documentroot:
   file.directory:
     - unless: test -d {{ documentroot }}
     - name: {{ documentroot }}
     - makedirs: True
+{% endif %}
 
 {% if grains.os_family == 'Debian' %}
 {% if site.get('enabled') %}


### PR DESCRIPTION
DocumentRoot is useless for a plain redirect or proxy vhost, no need to
force creating the directory.

Signed-off-by: Julien Cristau <julien.cristau@logilab.fr>