### PR TITLE
Don't execute `a2dissite` on each state run

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -43,6 +43,7 @@ a2ensite {{ id }}{{ apache.confext }}:
 a2dissite {{ id }}{{ apache.confext }}:
   cmd:
     - run
+    - onlyif: test -f /etc/apache2/sites-enabled/{{ id }}{{ apache.confext }}
     - require:
       - file: /etc/apache2/sites-available/{{ id }}{{ apache.confext }}
     - watch_in:


### PR DESCRIPTION
Add `onlyif` check to execute `a2dissite` only when needed.