### PR TITLE
Redhat module.sls fixes

### DIFF
--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -33,7 +33,7 @@ include:
 {% for module in salt['pillar.get']('apache:modules:enabled', []) %}
 find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(\s*LoadModule.{{ module }}_module\)/\2/g' {} \;:
   cmd.run:
-    - unless: httpd -M 2> /dev/null | grep '\s{{ module }}_module'
+    - unless: httpd -M 2> /dev/null | grep "[[:space:]]{{ module }}_module"
     - order: 225
     - require:
       - pkg: apache
@@ -44,7 +44,7 @@ find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(\s*LoadModule
 {% for module in salt['pillar.get']('apache:modules:disabled', []) %}
 find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^\s*LoadModule.{{ module }}_module\)/#\1/g' {} \;:
   cmd.run:
-    - onlyif: httpd -M 2> /dev/null | grep '\s{{ module }}_module'
+    - onlyif: httpd -M 2> /dev/null | grep "[[:space:]]{{ module }}_module"
     - order: 225
     - require:
       - pkg: apache

--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -31,7 +31,7 @@ include:
   - apache
  
 {% for module in salt['pillar.get']('apache:modules:enabled', []) %}
-find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(LoadModule.{{ module }}_module\)/\2/g' {} \;:
+find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(\s*LoadModule.{{ module }}_module\)/\2/g' {} \;:
   cmd.run:
     - unless: httpd -M 2> /dev/null | grep '\s{{ module }}_module'
     - order: 225
@@ -42,7 +42,7 @@ find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(LoadModule.{{
 {% endfor %}
 
 {% for module in salt['pillar.get']('apache:modules:disabled', []) %}
-find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^LoadModule.{{ module }}_module\)/#\1/g' {} \;:
+find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^\s*LoadModule.{{ module }}_module\)/#\1/g' {} \;:
   cmd.run:
     - onlyif: httpd -M 2> /dev/null | grep '\s{{ module }}_module'
     - order: 225

--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -33,7 +33,7 @@ include:
 {% for module in salt['pillar.get']('apache:modules:enabled', []) %}
 find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(LoadModule.{{ module }}_module\)/\2/g' {} \;:
   cmd.run:
-    - unless: httpd -M 2> /dev/null | grep {{ module }}_module
+    - unless: httpd -M 2> /dev/null | grep '\s{{ module }}_module'
     - order: 225
     - require:
       - pkg: apache
@@ -44,7 +44,7 @@ find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(LoadModule.{{
 {% for module in salt['pillar.get']('apache:modules:disabled', []) %}
 find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^LoadModule.{{ module }}_module\)/#\1/g' {} \;:
   cmd.run:
-    - onlyif: httpd -M 2> /dev/null | grep {{ module }}_module
+    - onlyif: httpd -M 2> /dev/null | grep '\s{{ module }}_module'
     - order: 225
     - require:
       - pkg: apache


### PR DESCRIPTION

* Add `[:space:]` in front of grep string else `{{ module }}` name may match excessively. For example, with the old code, module "cgi" would match both of these:
```
 proxy_scgi_module (shared)
 cgi_module (shared)
```

* Allow tabs and spaces in front of sed `LoadModule` .conf file matcher. This allows for comment/uncomment in cases where LoadModule/#LoadModule has tabs/or spaces preceding it - such as this real-world example:
```
<IfModule mpm_worker_module>
   LoadModule cgid_module modules/mod_cgid.so
</IfModule>
<IfModule mpm_event_module>
   LoadModule cgid_module modules/mod_cgid.so
</IfModule>
<IfModule mpm_prefork_module>
#   LoadModule cgi_module modules/mod_cgi.so
</IfModule>
```