### PR TITLE
Set vhost sites as enabled by default

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -30,7 +30,7 @@ include:
 {% endif %}
 
 {% if grains.os_family == 'Debian' %}
-{% if site.get('enabled') %}
+{% if site.get('enabled', True) %}
 a2ensite {{ id }}{{ apache.confext }}:
   cmd:
     - run


### PR DESCRIPTION
Sites defined for apache.vhost.standard are currently removed by default. Only by setting `enabled: true` explicitly are they enabled.
I think the default should be to add sites, not to remove them.