### PR TITLE
Added installation support for mod_pagespeed on RedHat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Enables the Apache module mod_headers. (Debian Only)
 ``apache.mod_pagespeed``
 ------------------------
 
-Installs and Enables the mod_pagespeed module. (Debian Only)
+Installs and Enables the mod_pagespeed module. (Debian and RedHat Only)
 
 ``apache.mod_php5``
 -------------------

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -9,6 +9,7 @@
         'mod_wsgi': 'libapache2-mod-wsgi',
         'mod_php5': 'libapache2-mod-php5',
         'mod_fcgid': 'libapache2-mod-fcgid',
+        'mod_pagespeed_source': 'https://dl-ssl.google.com/dl/linux/direct/mod-pagespeed-stable_current_amd64.deb',
 
         'vhostdir': '/etc/apache2/sites-available',
         'confdir': '/etc/apache2/conf.d',
@@ -26,6 +27,7 @@
 
         'mod_wsgi': 'mod_wsgi',
         'mod_php5': 'php',
+        'mod_pagespeed_source': 'https://dl-ssl.google.com/dl/linux/direct/mod-pagespeed-stable_current_x86_64.rpm',
 
         'vhostdir': '/etc/httpd/vhosts.d',
         'confdir': '/etc/httpd/conf.d',

--- a/apache/mod_pagespeed.sls
+++ b/apache/mod_pagespeed.sls
@@ -18,7 +18,6 @@ a2enmod pagespeed:
       - pkg: libapache2-mod-pagespeed
     - watch_in:
       - service: apache
-{% endif %}
 
 {% for dir in ['/var/cache/mod_pagespeed', '/var/log/pagespeed'] %}
 {{ dir }}:
@@ -33,7 +32,6 @@ a2enmod pagespeed:
       - group: {{ salt['pillar.get']('apache:group', 'www-data') }}
 {% endfor %}
 
-{% if grains['os_family']=="Debian" %}
 # Here we hardcode a logrotate entry to take care of the logs
 /etc/logrorate.d/pagespeed:
   file:

--- a/apache/mod_pagespeed.sls
+++ b/apache/mod_pagespeed.sls
@@ -1,4 +1,3 @@
-{% if grains['os_family']=="Debian" %}
 {% from "apache/map.jinja" import apache with context %}
 
 include:
@@ -8,9 +7,9 @@ libapache2-mod-pagespeed:
   pkg:
     - installed
     - sources:
-      - mod-pagespeed-stable: https://dl-ssl.google.com/dl/linux/direct/mod-pagespeed-stable_current_amd64.deb
+      - mod-pagespeed-stable: {{ apache.mod_pagespeed_source }}
 
-
+{% if grains['os_family']=="Debian" %}
 a2enmod pagespeed:
   cmd.run:
     - unless: ls /etc/apache2/mods-enabled/pagespeed.load
@@ -19,7 +18,7 @@ a2enmod pagespeed:
       - pkg: libapache2-mod-pagespeed
     - watch_in:
       - service: apache
-
+{% endif %}
 
 {% for dir in ['/var/cache/mod_pagespeed', '/var/log/pagespeed'] %}
 {{ dir }}:
@@ -34,6 +33,7 @@ a2enmod pagespeed:
       - group: {{ salt['pillar.get']('apache:group', 'www-data') }}
 {% endfor %}
 
+{% if grains['os_family']=="Debian" %}
 # Here we hardcode a logrotate entry to take care of the logs
 /etc/logrorate.d/pagespeed:
   file:
@@ -53,5 +53,4 @@ a2enmod pagespeed:
             fi;
           endscript
         }
-
 {% endif %}


### PR DESCRIPTION
Tested on CentOS 7. 

The /var/cache/mod_pagespeed and /var/log/mod_pagespeed are created by the RPM install with correct user settings, thats why I decided not to manage these directories from the formula. 

I am not sure about using logrotate on mod_pagespeed logs, I would expect that it corrupts the mod_pagespeed statistics, or doesn't it?