### PR TITLE
Added ability to manage security settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,10 @@ Example Pillar:
         example.com: # must be unique; used as an ID declaration in Salt; also passed to the template context as {{ id }}
           template_file: salt://apache/vhosts/standard.tmpl
 
+``apache.manage_security``
+--------------------------
+
+Configures Apache's security.conf options by reassinging them using data from Pillar.
 
 ``apache.debian_full``
 ----------------------

--- a/apache/manage_security.sls
+++ b/apache/manage_security.sls
@@ -1,0 +1,33 @@
+{% if grains['os_family']=="Debian" %}
+
+{% from "apache/map.jinja" import apache with context %}
+
+include:
+  - apache
+
+{% if salt['file.file_exists' ]('/etc/apache2/conf-available/security.conf') %}
+apache_security-block:
+  file.blockreplace:
+    - name: /etc/apache2/conf-available/security.conf
+    - marker_start: "# START managed zone -DO-NOT-EDIT-"
+    - marker_end: "# END managed zone --"
+    - append_if_not_found: True
+    - show_changes: True
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-reload
+
+{% for option, value in salt['pillar.get']('apache:security', {}).items() %}
+apache_manage-security-{{ option }}:
+  file.accumulated:
+    - filename: /etc/apache2/conf-available/security.conf
+    - name: apache_manage-security-add-{{ option }}
+    - text: "{{ option }} {{ value }}"
+    - require_in:
+      - file: apache_security-block
+{% endfor %}
+
+{% endif %}
+
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -115,3 +115,8 @@ apache:
       - ssl
     disabled:  # List modules to disable
       - rewrite
+
+  security:
+    # can be Full | OS | Minimal | Minor | Major | Prod
+    # where Full conveys the most information, and Prod the least.
+    ServerTokens: Prod


### PR DESCRIPTION
By reassigning options with `blockreplace` at `/etc/apache2/conf-available/security.conf`, which is linked as conf-enabled by default on Debian packages