### PR TITLE
Added ability to replace default vhost with own version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,11 @@ Enables the Apache module vhost_alias (Debian Only)
 
 Configures Apache name-based virtual hosts and creates virtual host directories using data from Pillar.
 
+``apache.own_default_vhost``
+--------------------------
+
+Replace default vhost with own version. By default, it's 503 code. (Debian Only)
+
 Example Pillar:
 
 .. code:: yaml

--- a/apache/files/Debian/sites-available/000-default.conf
+++ b/apache/files/Debian/sites-available/000-default.conf
@@ -1,0 +1,4 @@
+<VirtualHost *:80>
+	RewriteEngine on
+	RewriteRule ^/(.*) blah [R=503]
+</VirtualHost>

--- a/apache/own_default_vhost.sls
+++ b/apache/own_default_vhost.sls
@@ -1,0 +1,17 @@
+{% if grains['os_family']=="Debian" %}
+
+{% from "apache/map.jinja" import apache with context %}
+
+include:
+  - apache
+
+apache_own-default-vhost:
+  file.managed:
+    - name: {{ apache.vhostdir }}/000-default.conf
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/sites-available/000-default.conf
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-reload
+
+{% endif %}


### PR DESCRIPTION
Added example shows 503 code instead of "It works!" page.

(only Debian supported at the moment)