### PR TITLE
Fixed a typo in `apache.manage_security` pillar example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -119,4 +119,4 @@ apache:
   security:
     # can be Full | OS | Minimal | Minor | Major | Prod
     # where Full conveys the most information, and Prod the least.
-    ServerTokens: Prod
+    ServerTokens Prod


### PR DESCRIPTION
Whoops, my bad. :sweat_smile: Apache's format is not
```
Name: param
```
but
```
Name param
```