### PR TITLE
Added ability to configure mod_remoteip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,11 @@ Installs and enables the mod_fcgid module
 
 Enables the Apache module vhost_alias (Debian Only)
 
+``apache.mod_remoteip``
+----------------------
+
+Enables and configures the Apache module mod_remoteip using data from Pillar. (Debian Only)
+
 ``apache.vhosts.standard``
 --------------------------
 

--- a/apache/files/Debian/conf-available/remoteip.conf.jinja
+++ b/apache/files/Debian/conf-available/remoteip.conf.jinja
@@ -1,0 +1,4 @@
+RemoteIPHeader {{ salt['pillar.get']('apache:mod_remoteip:RemoteIPHeader', 'X-Forwarded-For') }}
+{%- for trusted_proxy in salt['pillar.get']('apache:mod_remoteip:RemoteIPTrustedProxy', []) %}
+RemoteIPTrustedProxy {{ trusted_proxy }}
+{%- endfor %}

--- a/apache/mod_remoteip.sls
+++ b/apache/mod_remoteip.sls
@@ -1,0 +1,25 @@
+{% if grains['os_family']=="Debian" %}
+
+include:
+  - apache
+
+a2enmod remoteip:
+  cmd.run:
+    - unless: ls /etc/apache2/mods-enabled/remoteip.load
+    - order: 255
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+
+/etc/apache2/conf-available/remoteip.conf:
+  file.managed:
+    - template: jinja
+    - source:
+      - salt://apache/files/{{ salt['grains.get']('os_family') }}/conf-available/remoteip.conf.jinja
+    - require:
+      - pkg: apache
+    - watch_in:
+      - service: apache
+
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -18,13 +18,6 @@ apache:
     # ``apache.mod_wsgi`` formula additional configuration:
     mod_wsgi: mod_wsgi
 
-    # ``apache.mod_remoteip`` formula additional configuration:
-    mod_remoteip:
-      RemoteIPHeader: X-Forwarded-For
-      RemoteIPTrustedProxy:
-        - 10.0.8.0/24
-        - 127.0.0.1
-
   # ``apache.vhosts`` formula additional configuration:
   sites:
     example.net:
@@ -127,3 +120,10 @@ apache:
     # can be Full | OS | Minimal | Minor | Major | Prod
     # where Full conveys the most information, and Prod the least.
     ServerTokens: Prod
+
+  # ``apache.mod_remoteip`` formula additional configuration:
+  mod_remoteip:
+    RemoteIPHeader: X-Forwarded-For
+    RemoteIPTrustedProxy:
+      - 10.0.8.0/24
+      - 127.0.0.1

--- a/pillar.example
+++ b/pillar.example
@@ -18,6 +18,13 @@ apache:
     # ``apache.mod_wsgi`` formula additional configuration:
     mod_wsgi: mod_wsgi
 
+    # ``apache.mod_remoteip`` formula additional configuration:
+    mod_remoteip:
+      RemoteIPHeader: X-Forwarded-For
+      RemoteIPTrustedProxy:
+        - 10.0.8.0/24
+        - 127.0.0.1
+
   # ``apache.vhosts`` formula additional configuration:
   sites:
     example.net:


### PR DESCRIPTION
Enables and configures the Apache module mod_remoteip using data from Pillar. (Debian Only)