### PR TITLE
Added ability to configure KeepAlive option

### DIFF
--- a/apache/files/Debian/apache-2.4.config.jinja
+++ b/apache/files/Debian/apache-2.4.config.jinja
@@ -91,7 +91,7 @@ Timeout 300
 # KeepAlive: Whether or not to allow persistent connections (more than
 # one request per connection). Set to "Off" to deactivate.
 #
-KeepAlive On
+KeepAlive {{ salt['pillar.get']('apache:keepalive', 'On') }}
 
 #
 # MaxKeepAliveRequests: The maximum number of requests to allow

--- a/pillar.example
+++ b/pillar.example
@@ -116,6 +116,10 @@ apache:
     disabled:  # List modules to disable
       - rewrite
 
+  # KeepAlive: Whether or not to allow persistent connections (more than
+  # one request per connection). Set to "Off" to deactivate.
+  keepalive: On
+
   security:
     # can be Full | OS | Minimal | Minor | Major | Prod
     # where Full conveys the most information, and Prod the least.

--- a/pillar.example
+++ b/pillar.example
@@ -118,7 +118,7 @@ apache:
 
   # KeepAlive: Whether or not to allow persistent connections (more than
   # one request per connection). Set to "Off" to deactivate.
-  keepalive: On
+  keepalive: 'On'
 
   security:
     # can be Full | OS | Minimal | Minor | Major | Prod


### PR DESCRIPTION
Sometimes it's necessary to be able to change this.
Ex.: "Off" is considered as recommended optimization in nginx+apache2 environment.
(only Debian at the moment, RedHat and Suse lacks "KeepAlive" option in existing files)