### PR TITLE
allow AllowEncodedSlashes directive in vhosts.

### DIFF
--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -13,6 +13,7 @@
 
     'DirectoryIndex': site.get('DirectoryIndex'),
     'UseCanonicalName': site.get('UseCanonicalName'),
+    'AllowEncodedSlashes': site.get('AllowEncodedSlashes'),
 
     'LogLevel': site.get('LogLevel', 'warn'),
     'ErrorLog': site.get('ErrorLog', '{0}/{1}-error.log'.format(map.logdir, sitename)),
@@ -47,6 +48,7 @@ Listen {{ vals.interface }}:{{ vals.port }}
 
     {% if site.get('DirectoryIndex') %}DirectoryIndex {{ vals.DirectoryIndex }}{% endif %}
     {% if site.get('UseCanonicalName') %}UseCanonicalName {{ vals.UseCanonicalName }}{% endif %}
+    {% if site.get('AllowEncodedSlashes') != False %}AllowEncodedSlashes {{ vals.AllowEncodedSlashes }}{% endif %}
 
     {% if site.get('LogLevel') != False %}LogLevel {{ vals.LogLevel }}{% endif %}
     {% if site.get('ErrorLog') != False %}ErrorLog {{ vals.ErrorLog }}{% endif %}


### PR DESCRIPTION
Apache2 docs state this is global, but vhost overrides it even when not specified.

additionally, this directive is defaulted differently across distributions (eg. CentOS is default 'On')

this change allows control of the directive.