### PR TITLE
Allow to configure several interfaces for a vhost.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,16 @@ Example Pillar:
         example.com: # must be unique; used as an ID declaration in Salt; also passed to the template context as {{ id }}
           template_file: salt://apache/vhosts/standard.tmpl
 
+When using the provided templates, one can use a space separated list
+of interfaces to bind to. For example, to bind both IPv4 and IPv6:
+	
+.. code:: yaml
+
+    apache:
+      sites:
+        example.com:
+          interface: '1.2.3.4 [2001:abc:def:100::3]'
+	  
 ``apache.manage_security``
 --------------------------
 

--- a/apache/vhosts/proxy.tmpl
+++ b/apache/vhosts/proxy.tmpl
@@ -3,7 +3,7 @@
 {% set sitename = site.get('ServerName', id) %}
 
 {% set vals = {
-    'interface': site.get('interface', '*'),
+    'interfaces': site.get('interface', '*').split(),
     'port': site.get('port', '80'),
 
     'ServerName': sitename,
@@ -22,9 +22,11 @@
     'ProxyRoute': site.get('ProxyRoute', {}),
 } %}
 
-Listen {{ vals.interface }}:{{ vals.port }}
+{% for intf in vals.interfaces -%}
+Listen {{ intf }}:{{ vals.port }}
+{% endfor %}
 
-<VirtualHost {{ vals.interface }}:{{ vals.port }}>
+<VirtualHost {%- for intf in vals.interfaces %} {{intf}}:{{ vals.port }}{% endfor -%}>
     ServerName {{ vals.ServerName }}
     {% if site.get('ServerAlias') != False %}ServerAlias {{ vals.ServerAlias }}{% endif %}
 

--- a/apache/vhosts/redirect.tmpl
+++ b/apache/vhosts/redirect.tmpl
@@ -3,7 +3,7 @@
 {% set sitename = site.get('ServerName', id) %}
 
 {% set vals = {
-    'interface': site.get('interface', '*'),
+    'interfaces': site.get('interface', '*').split(),
     'port': site.get('port', '80'),
 
     'ServerName': sitename,
@@ -23,9 +23,11 @@
 
 } %}
 
-Listen {{ vals.interface }}:{{ vals.port }}
+{% for intf in vals.interfaces -%}
+Listen {{ intf }}:{{ vals.port }}
+{% endfor %}
 
-<VirtualHost {{ vals.interface }}:{{ vals.port }}>
+<VirtualHost {%- for intf in vals.interfaces %} {{intf}}:{{ vals.port }}{% endfor -%}>
     ServerName {{ vals.ServerName }}
     {% if site.get('ServerAlias') != False %}ServerAlias {{ vals.ServerAlias }}{% endif %}
 

--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -3,7 +3,7 @@
 {% set sitename = site.get('ServerName', id) %}
 
 {% set vals = {
-    'interface': site.get('interface', '*'),
+    'interfaces': site.get('interface', '*').split(),
     'port': site.get('port', '80'),
 
     'ServerName': sitename,
@@ -38,9 +38,11 @@
     },
 } %}
 
-Listen {{ vals.interface }}:{{ vals.port }}
+{% for intf in vals.interfaces -%}
+Listen {{ intf }}:{{ vals.port }}
+{% endfor %}
 
-<VirtualHost {{ vals.interface }}:{{ vals.port }}>
+<VirtualHost {%- for intf in vals.interfaces %} {{intf}}:{{ vals.port }}{% endfor -%}>
     ServerName {{ vals.ServerName }}
     {% if site.get('ServerAlias') != False %}ServerAlias {{ vals.ServerAlias }}{% endif %}
 


### PR DESCRIPTION
This is done by splitting the interface pillar value instead of using a proper
list so it behaves exactly the same as before for simple 1 interface cases
(no need to refactor one's pillar files).

The resulting is something like:
```

  Listen 1.2.3.4:80
  Listen [2001:abc:def:100::3]:80

  <VirtualHost 1.2.3.4:80 [2001:abc:def:100::3]:80>
  ...

```
