### PR TITLE
Manage ports.conf file properly

### DIFF
--- a/apache/config.sls
+++ b/apache/config.sls
@@ -32,6 +32,19 @@ include:
       - pkg: apache
     - watch_in:
       - service: apache
+
+{{ apache.portsfile }}:
+  file.managed:
+    - template: jinja
+    - source:
+      - salt://apache/files/{{ salt['grains.get']('os_family') }}/ports-{{ apache.version }}.conf.jinja
+    - require:
+      - pkg: apache
+    - watch_in:
+      - service: apache
+    - context:
+      apache: {{ apache }}
+
 {% endif %}
 
 {% if grains['os_family']=="RedHat" %}

--- a/apache/debian_full.sls
+++ b/apache/debian_full.sls
@@ -37,9 +37,4 @@ a2dissite 000-default{{ apache.confext }}:
     - require:
       - pkg: apache
 
-/etc/apache2/ports.conf:
-  file.absent:
-    - require:
-      - pkg: apache
-
 {% endif %} #END: os = debian

--- a/apache/files/Debian/apache-2.4.config.jinja
+++ b/apache/files/Debian/apache-2.4.config.jinja
@@ -34,6 +34,10 @@
 #   together by including all remaining configuration files when starting up the
 #   web server.
 #
+# * ports.conf is always included from the main configuration file. It is
+#   supposed to determine listening ports for incoming connections which can be
+#   customized anytime.
+#
 # * Configuration files in the mods-enabled/, conf-enabled/ and sites-enabled/
 #   directories contain particular configuration snippets which manage modules,
 #   global configuration fragments, or virtual host configurations,
@@ -137,6 +141,9 @@ LogLevel warn
 # Include module configuration:
 IncludeOptional mods-enabled/*.load
 IncludeOptional mods-enabled/*.conf
+
+# Include list of ports to listen on
+Include ports.conf
 
 
 # Sets the default security model of the Apache2 HTTPD server. It does

--- a/apache/files/Debian/ports-2.4.conf.jinja
+++ b/apache/files/Debian/ports-2.4.conf.jinja
@@ -1,0 +1,30 @@
+{%- from "apache/map.jinja" import apache with context -%}
+
+# Managed by saltstack
+
+{% if salt['pillar.get']('apache:sites') is mapping %}
+    {%- set listen_directives = [] %}
+    {%- for id, site in salt['pillar.get']('apache:sites').items() %}
+        {%- set interfaces = site.get('interface', '*').split() %}
+        {%- set port = site.get('port', 80) %}
+        {%- for interface in interfaces %}
+            {%- set listen_directive = interface ~ ':' ~ port %}
+            {%- if listen_directive not in listen_directives %}
+                {%- do listen_directives.append(listen_directive) %}
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
+    {%- for listen in listen_directives %}
+Listen  {{ listen }}
+    {%- endfor %}
+{%- else %}
+Listen 80
+
+<IfModule mod_ssl.c>
+    Listen 443
+</IfModule>
+
+<IfModule mod_gnutls.c>
+    Listen 443
+</IfModule>
+{%- endif %}

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -5,6 +5,7 @@
         'server': 'apache2',
         'service': 'apache2',
         'configfile': '/etc/apache2/apache2.conf',
+        'portsfile': '/etc/apache2/ports.conf',
 
         'mod_wsgi': 'libapache2-mod-wsgi',
         'mod_php5': 'libapache2-mod-php5',

--- a/apache/vhosts/proxy.tmpl
+++ b/apache/vhosts/proxy.tmpl
@@ -22,10 +22,6 @@
     'ProxyRoute': site.get('ProxyRoute', {}),
 } %}
 
-{% for intf in vals.interfaces -%}
-Listen {{ intf }}:{{ vals.port }}
-{% endfor %}
-
 <VirtualHost {%- for intf in vals.interfaces %} {{intf}}:{{ vals.port }}{% endfor -%}>
     ServerName {{ vals.ServerName }}
     {% if site.get('ServerAlias') != False %}ServerAlias {{ vals.ServerAlias }}{% endif %}

--- a/apache/vhosts/redirect.tmpl
+++ b/apache/vhosts/redirect.tmpl
@@ -23,10 +23,6 @@
 
 } %}
 
-{% for intf in vals.interfaces -%}
-Listen {{ intf }}:{{ vals.port }}
-{% endfor %}
-
 <VirtualHost {%- for intf in vals.interfaces %} {{intf}}:{{ vals.port }}{% endfor -%}>
     ServerName {{ vals.ServerName }}
     {% if site.get('ServerAlias') != False %}ServerAlias {{ vals.ServerAlias }}{% endif %}

--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -2,6 +2,7 @@
 
 include:
   - apache
+  - apache.config
 
 {% for id, site in salt['pillar.get']('apache:sites', {}).items() %}
 {% set documentroot = site.get('DocumentRoot', '{0}/{1}'.format(apache.wwwdir, id)) %}

--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -38,10 +38,6 @@
     },
 } -%}
 
-{% for intf in vals.interfaces -%}
-Listen {{ intf }}:{{ vals.port }}
-{% endfor %}
-
 <VirtualHost {% for intf in vals.interfaces %} {{intf}}:{{ vals.port }}{% endfor -%}>
     ServerName {{ vals.ServerName }}
     {% if site.get('ServerAlias') != False %}ServerAlias {{ vals.ServerAlias }}{% endif %}


### PR DESCRIPTION
On basis of #106 
At first I removed all breaking changes introduces in #106. Then I decided ``ports.conf`` should be managed in the following way.
First, if there is no ``apache:sites`` defined in pillar like @jeffrysleddens pointed out, than use default ports.conf coming with installation.
Second, if this value is defined then take all ports and interfaces defined in all sites and combine them into the list of unique ``interface:port`` values and print them into ``ports.conf``.
Third, the ``ports.conf`` file should be manages in ``apache.config`` state as base configuration used by every apache2 installation.
Fourth, ``apache.config`` must be included to ``apache.vhosts.standard`` to be sure it's executed and there will be ``Listen`` directive.

Looking forward to seeing you feedback!