### PR TITLE
Fix bug when using ServerAdmin and DirectoryIndex

### DIFF
--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -42,7 +42,7 @@
     ServerName {{ vals.ServerName }}
     {% if site.get('ServerAlias') != False %}ServerAlias {{ vals.ServerAlias }}{% endif %}
 
-    {% if site.get('ServerAdmin') != False %}ServerAdmin {{ vals.ServerAdmin }}{% endif -%}
+    {% if site.get('ServerAdmin') != False %}ServerAdmin {{ vals.ServerAdmin }}{% endif %}
 
     {% if site.get('DirectoryIndex') -%}DirectoryIndex {{ vals.DirectoryIndex }}{% endif %}
     {% if site.get('UseCanonicalName') -%}UseCanonicalName {{ vals.UseCanonicalName }}{% endif %}


### PR DESCRIPTION
I've enabled ServerAdmin and DirectoryIndex in my pillar, as below:

```
apache:
  sites:
    examples:
      enabled: True
      template_file: salt://apache/vhosts/standard.tmpl
      template_engine: jinja
      interface: '*'
      port: '80'
      DirectoryIndex: index.php
      ServerName: examples.niwa.co.nz
      ServerAdmin: no-existing-user-example@localdomain
      LogLevel: info
      ErrorLog: /var/log/httpd/examples.niwa.co.nz-error.log
      CustomLog: /var/log/httpd/examples.niwa.co.nz-access.log
      LogFormat: combined
      DocumentRoot: /srv/www/vhosts/examples
      Directory:
        default:
          Options: -Indexes FollowSymlinks
          Require: all granted
          AllowOverride: None
```

But due to a `{% endif -%}`, with the dash to suppress a new line, my vhost is invalid, as the DirectoryIndex line gets appended after the ServerAdmin e-mail. Here what the generated vhost looks like.

```
<VirtualHost  *:80>
    ServerName examples.niwa.co.nz
    ServerAlias www.examples.niwa.co.nz

    ServerAdmin no-existing-user-example@localdomainDirectoryIndex index.php    #Here's the error
    
    AllowEncodedSlashes Off

    LogLevel info
    ErrorLog /var/log/httpd/examples.niwa.co.nz-error.log
    CustomLog /var/log/httpd/examples.niwa.co.nz-access.log combined

    DocumentRoot /srv/www/vhosts/examples
    

    <Directory "/var/www/examples.niwa.co.nz">
        Options -Indexes FollowSymlinks
        
        Order allow,deny
        Allow from all
        
        AllowOverride None
        

        
    </Directory>
</VirtualHost>
```