### PR TITLE
#125 activate ssl module

### DIFF
--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -1,0 +1,16 @@
+{% if grains['os_family']=="Debian" %}
+
+include:
+  - apache
+
+a2enmod mod_ssl:
+  cmd.run:
+    - name: a2enmod ssl
+    - unless: ls /etc/apache2/mods-enabled/ssl.load
+    - order: 225
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+
+{% endif %}


### PR DESCRIPTION
This is a way to activate ssl module from the apache formula with the state below:

- apache.mod_ssl