### PR TITLE
fix line feed suppression in standard.tmpl

### DIFF
--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -42,7 +42,7 @@
     ServerName {{ vals.ServerName }}
     {% if site.get('ServerAlias') != False %}ServerAlias {{ vals.ServerAlias }}{% endif %}
 
-    {% if site.get('ServerAdmin') != False %}ServerAdmin {{ vals.ServerAdmin }}{% endif -%}
+    {% if site.get('ServerAdmin') != False %}ServerAdmin {{ vals.ServerAdmin }}{% endif %}
 
     {% if site.get('DirectoryIndex') -%}DirectoryIndex {{ vals.DirectoryIndex }}{% endif %}
     {% if site.get('UseCanonicalName') -%}UseCanonicalName {{ vals.UseCanonicalName }}{% endif %}


### PR DESCRIPTION
before, when you had ServerAdmin and DirectoryIndex set for a site, you would end up with a config file line like:

ServerAdmin hostmaster@example.comDirectoryIndex index.php