### PR TITLE
let Directory_default actually use DocumentRoot if set, not always de…

### DIFF
--- a/apache/files/Debian/envvars.jinja
+++ b/apache/files/Debian/envvars.jinja
@@ -47,3 +47,8 @@ export LANG
 ## This will produce a verbose output on package installations of web server modules and web application
 ## installations which interact with Apache
 #export APACHE2_MAINTSCRIPT_DEBUG=1
+
+{% if salt['pillar.get']('apache:umask') %}
+# umask 002 to create files with 0664 and folders with 0775
+umask {{ salt['pillar.get']('apache:umask') }}
+{%- endif %}

--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -23,7 +23,7 @@
     'DocumentRoot': site.get('DocumentRoot', '{0}/{1}'.format(map.wwwdir, sitename)),
     'VirtualDocumentRoot': site.get('VirtualDocumentRoot'),
 
-    'Directory_default': '{0}/{1}'.format(map.wwwdir, sitename),
+    'Directory_default': site.get('DocumentRoot', '{0}/{1}'.format(map.wwwdir, sitename)),
     'Directory': {
         'Options': '-Indexes +FollowSymLinks',
         'Order': 'allow,deny',

--- a/pillar.example
+++ b/pillar.example
@@ -18,6 +18,9 @@ apache:
     # ``apache.mod_wsgi`` formula additional configuration:
     mod_wsgi: mod_wsgi
 
+  # optionally define umask to be placed in envvars (Debian only)
+  umask: '022'
+
   global:
     # global apache directives
     AllowEncodedSlashes: "On"


### PR DESCRIPTION
the standard.tmpl was not considering the DocumentRoot for the default Directory, but instead always used the default value `'{0}/{1}'.format(map.wwwdir, sitename)`
