### PR TITLE
Add support for name based virtual hosts

### DIFF
--- a/apache/files/Debian/ports-2.2.conf.jinja
+++ b/apache/files/Debian/ports-2.2.conf.jinja
@@ -28,3 +28,18 @@ Listen 80
     Listen 443
 </IfModule>
 {%- endif %}
+
+{%- if salt['pillar.get']('apache:name_virtual_hosts') is iterable %}
+    {%- set name_virtual_host_directives = [] %}
+
+    {%- for name_virtual_host in salt['pillar.get']('apache:name_virtual_hosts') %}
+        {%- set interface = name_virtual_host.get('interface', '*') %}
+        {%- set port = name_virtual_host.get('port', 80) %}
+        {%- set name_virtual_host_directive = interface ~ ':' ~ port %}
+        {%- do name_virtual_host_directives.append(name_virtual_host_directive) %}
+    {%- endfor %}
+
+    {%- for name_virtual_host in name_virtual_host_directives %}
+NameVirtualHost  {{ name_virtual_host }}
+    {%- endfor %}
+{%- endif -%}

--- a/apache/files/Debian/ports-2.4.conf.jinja
+++ b/apache/files/Debian/ports-2.4.conf.jinja
@@ -28,3 +28,18 @@ Listen 80
     Listen 443
 </IfModule>
 {%- endif %}
+
+{%- if salt['pillar.get']('apache:name_virtual_hosts') is iterable %}
+    {%- set name_virtual_host_directives = [] %}
+
+    {%- for name_virtual_host in salt['pillar.get']('apache:name_virtual_hosts') %}
+        {%- set interface = name_virtual_host.get('interface', '*') %}
+        {%- set port = name_virtual_host.get('port', 80) %}
+        {%- set name_virtual_host_directive = interface ~ ':' ~ port %}
+        {%- do name_virtual_host_directives.append(name_virtual_host_directive) %}
+    {%- endfor %}
+
+    {%- for name_virtual_host in name_virtual_host_directives %}
+NameVirtualHost  {{ name_virtual_host }}
+    {%- endfor %}
+{%- endif -%}

--- a/pillar.example
+++ b/pillar.example
@@ -23,6 +23,12 @@ apache:
     AllowEncodedSlashes: "On"
 
 
+  name_virtual_hosts:
+    - interface: *
+      port: 80
+    - interface: *
+      port: 443
+
   # ``apache.vhosts`` formula additional configuration:
   sites:
     example.net:


### PR DESCRIPTION
**Summary of Changes**
 * This PR adds support for the NameVirtualHost directive
  * With this PR, name based virtual hosts are automatically activated when multiple sites on the same interface and port are configured. The question is, should this be configurable or not? Would it even make sense to have multiple sites on the same port without name based virtual hosts?

**Testing**
 - Tested in Vagrant
 - Tested on OS 

