### PR TITLE
multiple commits for rhel (7), use watch module: apache-[restart|reload] consequently, make Listen more modular, mod_ssl for rhel, server-status state(for clusters like Pacemaker)

### DIFF
--- a/apache/config.sls
+++ b/apache/config.sls
@@ -11,7 +11,7 @@ include:
     - require:
       - pkg: apache
     - watch_in:
-      - service: apache
+      - module: apache-restart
     - context:
       apache: {{ apache }}
 
@@ -20,7 +20,7 @@ include:
     - require:
       - pkg: apache
     - watch_in:
-      - service: apache
+      - module: apache-restart
 
 {% if grains['os_family']=="Debian" %}
 /etc/apache2/envvars:
@@ -31,7 +31,7 @@ include:
     - require:
       - pkg: apache
     - watch_in:
-      - service: apache
+      - module: apache-restart
 
 {{ apache.portsfile }}:
   file.managed:
@@ -41,7 +41,7 @@ include:
     - require:
       - pkg: apache
     - watch_in:
-      - service: apache
+      - module: apache-restart
     - context:
       apache: {{ apache }}
 
@@ -53,7 +53,7 @@ include:
     - require:
       - pkg: apache
     - watch_in:
-      - service: apache
+      - module: apache-restart
 {% endif %}
 
 {% if grains['os_family']=="Suse" %}
@@ -65,7 +65,7 @@ include:
     - require:
       - pkg: apache
     - watch_in:
-      - service: apache
+      - module: apache-restart
     - context:
       apache: {{ apache }}
 {% endif %}

--- a/apache/config.sls
+++ b/apache/config.sls
@@ -12,6 +12,10 @@ include:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
     - context:
       apache: {{ apache }}
 
@@ -21,6 +25,10 @@ include:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% if grains['os_family']=="Debian" %}
 /etc/apache2/envvars:
@@ -32,6 +40,10 @@ include:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {{ apache.portsfile }}:
   file.managed:
@@ -42,6 +54,10 @@ include:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
     - context:
       apache: {{ apache }}
 
@@ -54,6 +70,10 @@ include:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 {% endif %}
 
 {% if grains['os_family']=="Suse" %}
@@ -66,6 +86,10 @@ include:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
     - context:
       apache: {{ apache }}
 {% endif %}

--- a/apache/debian_full.sls
+++ b/apache/debian_full.sls
@@ -24,6 +24,10 @@ a2dissite 000-default{{ apache.confext }}:
     - onlyif: test -f /etc/apache2/sites-enabled/000-default{{ apache.confext }}
     - watch_in:
       - module: apache-reload
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
     - require:
       - pkg: apache
 

--- a/apache/defaults.yaml
+++ b/apache/defaults.yaml
@@ -1,0 +1,2 @@
+service_state: enabled
+service_enable: True

--- a/apache/defaults.yaml
+++ b/apache/defaults.yaml
@@ -1,2 +1,2 @@
-service_state: enabled
+service_state: running
 service_enable: True

--- a/apache/files/Debian/ports-2.2.conf.jinja
+++ b/apache/files/Debian/ports-2.2.conf.jinja
@@ -18,15 +18,18 @@
 Listen  {{ listen }}
     {%- endfor %}
 {%- else %}
-Listen 80
+{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '*:80') %}
+{%- if standard_listen_directive %}
+Listen  {{ standard_listen_directive }}
+{%- endif %}
 
-<IfModule mod_ssl.c>
-    Listen 443
-</IfModule>
+#<IfModule mod_ssl.c>
+#    Listen 443
+#</IfModule>
 
-<IfModule mod_gnutls.c>
-    Listen 443
-</IfModule>
+#<IfModule mod_gnutls.c>
+#    Listen 443
+#</IfModule>
 {%- endif %}
 
 {%- if salt['pillar.get']('apache:name_virtual_hosts') is iterable %}

--- a/apache/files/Debian/ports-2.2.conf.jinja
+++ b/apache/files/Debian/ports-2.2.conf.jinja
@@ -18,18 +18,21 @@
 Listen  {{ listen }}
     {%- endfor %}
 {%- else %}
-{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '*:80') %}
+{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '80') %}
 {%- if standard_listen_directive %}
 Listen  {{ standard_listen_directive }}
 {%- endif %}
 
-#<IfModule mod_ssl.c>
-#    Listen 443
-#</IfModule>
+{%- set standard_listen_directive_ssl = salt['pillar.get']('apache:standard_listen_directive_ssl', '443') %}
+{%- if standard_listen_directive_ssl %}
+<IfModule mod_ssl.c>
+    Listen {{ standard_listen_directive_ssl }}
+</IfModule>
 
-#<IfModule mod_gnutls.c>
-#    Listen 443
-#</IfModule>
+<IfModule mod_gnutls.c>
+    Listen {{ standard_listen_directive_ssl }}
+</IfModule>
+{%- endif %}
 {%- endif %}
 
 {%- if salt['pillar.get']('apache:name_virtual_hosts') is iterable %}

--- a/apache/files/Debian/ports-2.2.conf.jinja
+++ b/apache/files/Debian/ports-2.2.conf.jinja
@@ -18,19 +18,17 @@
 Listen  {{ listen }}
     {%- endfor %}
 {%- else %}
-{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '80') %}
-{%- if standard_listen_directive %}
-Listen  {{ standard_listen_directive }}
+{%- if apache.get('standard_listen_directive') != False %}
+Listen  {{ apache.standard_listen_directive|default('80') }}
 {%- endif %}
 
-{%- set standard_listen_directive_ssl = salt['pillar.get']('apache:standard_listen_directive_ssl', '443') %}
-{%- if standard_listen_directive_ssl %}
+{%- if apache.get('standard_listen_directive_ssl') != False %}
 <IfModule mod_ssl.c>
-    Listen {{ standard_listen_directive_ssl }}
+    Listen  {{ apache.standard_listen_directive_ssl|default('443') }}
 </IfModule>
 
 <IfModule mod_gnutls.c>
-    Listen {{ standard_listen_directive_ssl }}
+    Listen  {{ apache.standard_listen_directive_ssl|default('443') }}
 </IfModule>
 {%- endif %}
 {%- endif %}

--- a/apache/files/Debian/ports-2.4.conf.jinja
+++ b/apache/files/Debian/ports-2.4.conf.jinja
@@ -18,15 +18,18 @@
 Listen  {{ listen }}
     {%- endfor %}
 {%- else %}
-Listen 80
+{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '*:80') %}
+{%- if standard_listen_directive %}
+Listen  {{ standard_listen_directive }}
+{%- endif %}
 
-<IfModule mod_ssl.c>
-    Listen 443
-</IfModule>
+#<IfModule mod_ssl.c>
+#    Listen 443
+#</IfModule>
 
-<IfModule mod_gnutls.c>
-    Listen 443
-</IfModule>
+#<IfModule mod_gnutls.c>
+#    Listen 443
+#</IfModule>
 {%- endif %}
 
 {%- if salt['pillar.get']('apache:name_virtual_hosts') is iterable %}

--- a/apache/files/Debian/ports-2.4.conf.jinja
+++ b/apache/files/Debian/ports-2.4.conf.jinja
@@ -18,18 +18,21 @@
 Listen  {{ listen }}
     {%- endfor %}
 {%- else %}
-{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '*:80') %}
+{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '80') %}
 {%- if standard_listen_directive %}
 Listen  {{ standard_listen_directive }}
 {%- endif %}
 
-#<IfModule mod_ssl.c>
-#    Listen 443
-#</IfModule>
+{%- set standard_listen_directive_ssl = salt['pillar.get']('apache:standard_listen_directive_ssl', '443') %}
+{%- if standard_listen_directive_ssl %}
+<IfModule mod_ssl.c>
+    Listen {{ standard_listen_directive_ssl }}
+</IfModule>
 
-#<IfModule mod_gnutls.c>
-#    Listen 443
-#</IfModule>
+<IfModule mod_gnutls.c>
+    Listen {{ standard_listen_directive_ssl }}
+</IfModule>
+{%- endif %}
 {%- endif %}
 
 {%- if salt['pillar.get']('apache:name_virtual_hosts') is iterable %}

--- a/apache/files/Debian/ports-2.4.conf.jinja
+++ b/apache/files/Debian/ports-2.4.conf.jinja
@@ -18,19 +18,17 @@
 Listen  {{ listen }}
     {%- endfor %}
 {%- else %}
-{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '80') %}
-{%- if standard_listen_directive %}
-Listen  {{ standard_listen_directive }}
+{%- if apache.get('standard_listen_directive') != False %}
+Listen  {{ apache.standard_listen_directive|default('80') }}
 {%- endif %}
 
-{%- set standard_listen_directive_ssl = salt['pillar.get']('apache:standard_listen_directive_ssl', '443') %}
-{%- if standard_listen_directive_ssl %}
+{%- if apache.get('standard_listen_directive_ssl') != False %}
 <IfModule mod_ssl.c>
-    Listen {{ standard_listen_directive_ssl }}
+    Listen  {{ apache.standard_listen_directive_ssl|default('443') }}
 </IfModule>
 
 <IfModule mod_gnutls.c>
-    Listen {{ standard_listen_directive_ssl }}
+    Listen  {{ apache.standard_listen_directive_ssl|default('443') }}
 </IfModule>
 {%- endif %}
 {%- endif %}

--- a/apache/files/RedHat/apache-2.2.config.jinja
+++ b/apache/files/RedHat/apache-2.2.config.jinja
@@ -1,3 +1,4 @@
+{%- from "apache/map.jinja" import apache with context -%}
 #
 # This is the main Apache HTTP server configuration file.  It contains the
 # configuration directives that give the server its instructions.
@@ -39,9 +40,8 @@ ServerRoot "/etc/httpd"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '80') %}
-{%- if standard_listen_directive %}
-Listen  {{ standard_listen_directive }}
+{%- if apache.get('standard_listen_directive') != False %}
+Listen  {{ apache.standard_listen_directive|default('80') }}
 {%- endif %}
 
 #

--- a/apache/files/RedHat/apache-2.2.config.jinja
+++ b/apache/files/RedHat/apache-2.2.config.jinja
@@ -39,7 +39,7 @@ ServerRoot "/etc/httpd"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '*:80') %}
+{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '80') %}
 {%- if standard_listen_directive %}
 Listen  {{ standard_listen_directive }}
 {%- endif %}

--- a/apache/files/RedHat/apache-2.2.config.jinja
+++ b/apache/files/RedHat/apache-2.2.config.jinja
@@ -39,7 +39,10 @@ ServerRoot "/etc/httpd"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 80
+{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '*:80') %}
+{%- if standard_listen_directive %}
+Listen  {{ standard_listen_directive }}
+{%- endif %}
 
 #
 # Dynamic Shared Object (DSO) Support

--- a/apache/files/RedHat/apache-2.4.config.jinja
+++ b/apache/files/RedHat/apache-2.4.config.jinja
@@ -1,3 +1,4 @@
+{%- from "apache/map.jinja" import apache with context -%}
 #
 # This is the main Apache HTTP server configuration file.  It contains the
 # configuration directives that give the server its instructions.
@@ -39,9 +40,8 @@ ServerRoot "/etc/httpd"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '80') %}
-{%- if standard_listen_directive %}
-Listen  {{ standard_listen_directive }}
+{%- if apache.get('standard_listen_directive') != False %}
+Listen  {{ apache.standard_listen_directive|default('80') }}
 {%- endif %}
 
 #

--- a/apache/files/RedHat/apache-2.4.config.jinja
+++ b/apache/files/RedHat/apache-2.4.config.jinja
@@ -39,7 +39,7 @@ ServerRoot "/etc/httpd"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '*:80') %}
+{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '80') %}
 {%- if standard_listen_directive %}
 Listen  {{ standard_listen_directive }}
 {%- endif %}

--- a/apache/files/RedHat/apache-2.4.config.jinja
+++ b/apache/files/RedHat/apache-2.4.config.jinja
@@ -39,7 +39,10 @@ ServerRoot "/etc/httpd"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 80
+{%- set standard_listen_directive = salt['pillar.get']('apache:standard_listen_directive', '*:80') %}
+{%- if standard_listen_directive %}
+Listen  {{ standard_listen_directive }}
+{%- endif %}
 
 #
 # Dynamic Shared Object (DSO) Support

--- a/apache/files/RedHat/ssl.conf.jinja
+++ b/apache/files/RedHat/ssl.conf.jinja
@@ -1,0 +1,221 @@
+#
+# When we also provide SSL we have to listen to the 
+# the HTTPS port in addition.
+#
+{%- set standard_listen_directive_ssl = salt['pillar.get']('apache:standard_listen_directive_ssl', '443 https') %}
+{%- if standard_listen_directive_ssl %}
+Listen {{ standard_listen_directive_ssl }}
+{%- endif %}
+
+##
+##  SSL Global Context
+##
+##  All SSL configuration in this context applies both to
+##  the main server and all SSL-enabled virtual hosts.
+##
+
+#   Pass Phrase Dialog:
+#   Configure the pass phrase gathering process.
+#   The filtering dialog program (`builtin' is a internal
+#   terminal dialog) has to provide the pass phrase on stdout.
+SSLPassPhraseDialog exec:/usr/libexec/httpd-ssl-pass-dialog
+
+#   Inter-Process Session Cache:
+#   Configure the SSL Session Cache: First the mechanism 
+#   to use and second the expiring timeout (in seconds).
+SSLSessionCache         shmcb:/run/httpd/sslcache(512000)
+SSLSessionCacheTimeout  300
+
+#   Pseudo Random Number Generator (PRNG):
+#   Configure one or more sources to seed the PRNG of the 
+#   SSL library. The seed data should be of good random quality.
+#   WARNING! On some platforms /dev/random blocks if not enough entropy
+#   is available. This means you then cannot use the /dev/random device
+#   because it would lead to very long connection times (as long as
+#   it requires to make more entropy available). But usually those
+#   platforms additionally provide a /dev/urandom device which doesn't
+#   block. So, if available, use this one instead. Read the mod_ssl User
+#   Manual for more details.
+SSLRandomSeed startup file:/dev/urandom  256
+SSLRandomSeed connect builtin
+#SSLRandomSeed startup file:/dev/random  512
+#SSLRandomSeed connect file:/dev/random  512
+#SSLRandomSeed connect file:/dev/urandom 512
+
+#
+# Use "SSLCryptoDevice" to enable any supported hardware
+# accelerators. Use "openssl engine -v" to list supported
+# engine names.  NOTE: If you enable an accelerator and the
+# server does not start, consult the error logs and ensure
+# your accelerator is functioning properly. 
+#
+SSLCryptoDevice builtin
+#SSLCryptoDevice ubsec
+
+##
+## SSL Virtual Host Context
+##
+{% set ssl_default_host_enabled = salt['pillar.get']('apache:ssl_default_host_enabled', False) %}
+{%- if ssl_default_host_enabled %}
+<VirtualHost _default_:443>
+
+# General setup for the virtual host, inherited from global configuration
+#DocumentRoot "/var/www/html"
+#ServerName www.example.com:443
+
+# Use separate log files for the SSL virtual host; note that LogLevel
+# is not inherited from httpd.conf.
+ErrorLog logs/ssl_error_log
+TransferLog logs/ssl_access_log
+LogLevel warn
+
+#   SSL Engine Switch:
+#   Enable/Disable SSL for this virtual host.
+SSLEngine on
+
+#   SSL Protocol support:
+# List the enable protocol levels with which clients will be able to
+# connect.  Disable SSLv2 access by default:
+SSLProtocol all -SSLv2
+
+#   SSL Cipher Suite:
+#   List the ciphers that the client is permitted to negotiate.
+#   See the mod_ssl documentation for a complete list.
+SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5:!SEED:!IDEA
+
+#   Speed-optimized SSL Cipher configuration:
+#   If speed is your main concern (on busy HTTPS servers e.g.),
+#   you might want to force clients to specific, performance
+#   optimized ciphers. In this case, prepend those ciphers
+#   to the SSLCipherSuite list, and enable SSLHonorCipherOrder.
+#   Caveat: by giving precedence to RC4-SHA and AES128-SHA
+#   (as in the example below), most connections will no longer
+#   have perfect forward secrecy - if the server's key is
+#   compromised, captures of past or future traffic must be
+#   considered compromised, too.
+#SSLCipherSuite RC4-SHA:AES128-SHA:HIGH:MEDIUM:!aNULL:!MD5
+#SSLHonorCipherOrder on 
+
+#   Server Certificate:
+# Point SSLCertificateFile at a PEM encoded certificate.  If
+# the certificate is encrypted, then you will be prompted for a
+# pass phrase.  Note that a kill -HUP will prompt again.  A new
+# certificate can be generated using the genkey(1) command.
+SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+
+#   Server Private Key:
+#   If the key is not combined with the certificate, use this
+#   directive to point at the key file.  Keep in mind that if
+#   you've both a RSA and a DSA private key you can configure
+#   both in parallel (to also allow the use of DSA ciphers, etc.)
+SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+
+#   Server Certificate Chain:
+#   Point SSLCertificateChainFile at a file containing the
+#   concatenation of PEM encoded CA certificates which form the
+#   certificate chain for the server certificate. Alternatively
+#   the referenced file can be the same as SSLCertificateFile
+#   when the CA certificates are directly appended to the server
+#   certificate for convinience.
+#SSLCertificateChainFile /etc/pki/tls/certs/server-chain.crt
+
+#   Certificate Authority (CA):
+#   Set the CA certificate verification path where to find CA
+#   certificates for client authentication or alternatively one
+#   huge file containing all of them (file must be PEM encoded)
+#SSLCACertificateFile /etc/pki/tls/certs/ca-bundle.crt
+
+#   Client Authentication (Type):
+#   Client certificate verification type and depth.  Types are
+#   none, optional, require and optional_no_ca.  Depth is a
+#   number which specifies how deeply to verify the certificate
+#   issuer chain before deciding the certificate is not valid.
+#SSLVerifyClient require
+#SSLVerifyDepth  10
+
+#   Access Control:
+#   With SSLRequire you can do per-directory access control based
+#   on arbitrary complex boolean expressions containing server
+#   variable checks and other lookup directives.  The syntax is a
+#   mixture between C and Perl.  See the mod_ssl documentation
+#   for more details.
+#<Location />
+#SSLRequire (    %{SSL_CIPHER} !~ m/^(EXP|NULL)/ \
+#            and %{SSL_CLIENT_S_DN_O} eq "Snake Oil, Ltd." \
+#            and %{SSL_CLIENT_S_DN_OU} in {"Staff", "CA", "Dev"} \
+#            and %{TIME_WDAY} >= 1 and %{TIME_WDAY} <= 5 \
+#            and %{TIME_HOUR} >= 8 and %{TIME_HOUR} <= 20       ) \
+#           or %{REMOTE_ADDR} =~ m/^192\.76\.162\.[0-9]+$/
+#</Location>
+
+#   SSL Engine Options:
+#   Set various options for the SSL engine.
+#   o FakeBasicAuth:
+#     Translate the client X.509 into a Basic Authorisation.  This means that
+#     the standard Auth/DBMAuth methods can be used for access control.  The
+#     user name is the `one line' version of the client's X.509 certificate.
+#     Note that no password is obtained from the user. Every entry in the user
+#     file needs this password: `xxj31ZMTZzkVA'.
+#   o ExportCertData:
+#     This exports two additional environment variables: SSL_CLIENT_CERT and
+#     SSL_SERVER_CERT. These contain the PEM-encoded certificates of the
+#     server (always existing) and the client (only existing when client
+#     authentication is used). This can be used to import the certificates
+#     into CGI scripts.
+#   o StdEnvVars:
+#     This exports the standard SSL/TLS related `SSL_*' environment variables.
+#     Per default this exportation is switched off for performance reasons,
+#     because the extraction step is an expensive operation and is usually
+#     useless for serving static content. So one usually enables the
+#     exportation for CGI and SSI requests only.
+#   o StrictRequire:
+#     This denies access when "SSLRequireSSL" or "SSLRequire" applied even
+#     under a "Satisfy any" situation, i.e. when it applies access is denied
+#     and no other module can change it.
+#   o OptRenegotiate:
+#     This enables optimized SSL connection renegotiation handling when SSL
+#     directives are used in per-directory context. 
+#SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
+<Files ~ "\.(cgi|shtml|phtml|php3?)$">
+    SSLOptions +StdEnvVars
+</Files>
+<Directory "/var/www/cgi-bin">
+    SSLOptions +StdEnvVars
+</Directory>
+
+#   SSL Protocol Adjustments:
+#   The safe and default but still SSL/TLS standard compliant shutdown
+#   approach is that mod_ssl sends the close notify alert but doesn't wait for
+#   the close notify alert from client. When you need a different shutdown
+#   approach you can use one of the following variables:
+#   o ssl-unclean-shutdown:
+#     This forces an unclean shutdown when the connection is closed, i.e. no
+#     SSL close notify alert is send or allowed to received.  This violates
+#     the SSL/TLS standard but is needed for some brain-dead browsers. Use
+#     this when you receive I/O errors because of the standard approach where
+#     mod_ssl sends the close notify alert.
+#   o ssl-accurate-shutdown:
+#     This forces an accurate shutdown when the connection is closed, i.e. a
+#     SSL close notify alert is send and mod_ssl waits for the close notify
+#     alert of the client. This is 100% SSL/TLS standard compliant, but in
+#     practice often causes hanging connections with brain-dead browsers. Use
+#     this only for browsers where you know that their SSL implementation
+#     works correctly. 
+#   Notice: Most problems of broken clients are also related to the HTTP
+#   keep-alive facility, so you usually additionally want to disable
+#   keep-alive for those clients, too. Use variable "nokeepalive" for this.
+#   Similarly, one has to force some clients to use HTTP/1.0 to workaround
+#   their broken HTTP/1.1 implementation. Use variables "downgrade-1.0" and
+#   "force-response-1.0" for this.
+BrowserMatch "MSIE [2-5]" \
+         nokeepalive ssl-unclean-shutdown \
+         downgrade-1.0 force-response-1.0
+
+#   Per-Server Logging:
+#   The home of a custom SSL log file. Use this when you want a
+#   compact non-error SSL logfile on a virtual host basis.
+CustomLog logs/ssl_request_log \
+          "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+
+</VirtualHost>                                  
+{% endif %}

--- a/apache/files/RedHat/ssl.conf.jinja
+++ b/apache/files/RedHat/ssl.conf.jinja
@@ -1,10 +1,10 @@
+{%- from "apache/map.jinja" import apache with context -%}
 #
 # When we also provide SSL we have to listen to the 
 # the HTTPS port in addition.
 #
-{%- set standard_listen_directive_ssl = salt['pillar.get']('apache:standard_listen_directive_ssl', '443 https') %}
-{%- if standard_listen_directive_ssl %}
-Listen {{ standard_listen_directive_ssl }}
+{%- if apache.get('standard_listen_directive_ssl') != False %}
+Listen  {{ apache.standard_listen_directive_ssl|default('443 https') }}
 {%- endif %}
 
 ##

--- a/apache/files/server-status.conf
+++ b/apache/files/server-status.conf
@@ -1,0 +1,6 @@
+<Location /server-status>
+    SetHandler server-status
+    Order deny,allow
+    Deny from all
+    Allow from localhost
+</Location>

--- a/apache/init.sls
+++ b/apache/init.sls
@@ -18,7 +18,7 @@ apache-reload:
     - m_name: {{ apache.service }}
 {% else %}
     - name: cmd.run
-    - m_name: {{ apache.service }} -k graceful
+    - m_name: ps -ef |grep {{ apache.service }}|grep -v grep && {{ apache.service }} -k graceful
 {% endif %}
 
 apache-restart:
@@ -32,5 +32,5 @@ apache-restart:
 # cluster manager like Pacemaker
   module.wait:
     - name: cmd.run
-    - m_name: {{ apache.service }} -k graceful
+    - m_name: ps -ef |grep {{ apache.service }}|grep -v grep && {{ apache.service }} -k graceful
 {% endif %}

--- a/apache/init.sls
+++ b/apache/init.sls
@@ -1,5 +1,4 @@
 {% from "apache/map.jinja" import apache with context %}
-{% set restart_command = 
 
 apache:
   pkg.installed:

--- a/apache/init.sls
+++ b/apache/init.sls
@@ -18,7 +18,8 @@ apache-reload:
     - m_name: {{ apache.service }}
 {% else %}
     - name: cmd.run
-    - m_name: ps -ef |grep {{ apache.service }}|grep -v grep && {{ apache.service }} -k graceful
+    - cmd: "ps -ef | grep {{ apache.service }} | grep -v grep && {{ apache.service }} -k graceful"
+    - python_shell: True
 {% endif %}
 
 apache-restart:
@@ -32,5 +33,6 @@ apache-restart:
 # cluster manager like Pacemaker
   module.wait:
     - name: cmd.run
-    - m_name: ps -ef |grep {{ apache.service }}|grep -v grep && {{ apache.service }} -k graceful
+    - cmd: "ps -ef | grep {{ apache.service }} | grep -v grep && {{ apache.service }} -k graceful"
+    - python_shell: True
 {% endif %}

--- a/apache/init.sls
+++ b/apache/init.sls
@@ -1,4 +1,5 @@
 {% from "apache/map.jinja" import apache with context %}
+{% set restart_command = 
 
 apache:
   pkg.installed:
@@ -18,7 +19,7 @@ apache-reload:
     - m_name: {{ apache.service }}
 {% else %}
     - name: cmd.run
-    - cmd: "ps -ef | grep {{ apache.server }} | grep -v grep && {{ apache.service }} -k graceful"
+    - cmd: {{apache.custom_reload_command|default('apachectl graceful')}}
     - python_shell: True
 {% endif %}
 
@@ -28,11 +29,8 @@ apache-restart:
     - name: service.restart
     - m_name: {{ apache.service }}
 {% else %}
-# a bit hackish, but reload doesnt start apache when it is not running
-# needed when service_state is disabled but apache is controlled by a 
-# cluster manager like Pacemaker
   module.wait:
     - name: cmd.run
-    - cmd: "ps -ef | grep {{ apache.server }} | grep -v grep && {{ apache.service }} -k graceful"
+    - cmd: {{apache.custom_restart_command|default('apachectl restart')}}
     - python_shell: True
 {% endif %}

--- a/apache/init.sls
+++ b/apache/init.sls
@@ -13,8 +13,13 @@ apache:
 # trigger a restart or reload as needed.
 apache-reload:
   module.wait:
+{% if apache.service_state in ['running'] %}
     - name: service.reload
     - m_name: {{ apache.service }}
+{% else %}
+    - name: cmd.run
+    - m_name: {{ apache.service }} -k graceful
+{% endif %}
 
 apache-restart:
 {% if apache.service_state in ['running'] %}
@@ -26,6 +31,6 @@ apache-restart:
 # needed when service_state is disabled but apache is controlled by a 
 # cluster manager like Pacemaker
   module.wait:
-    - name: service.reload
-    - m_name: {{ apache.service }}
+    - name: cmd.run
+    - m_name: {{ apache.service }} -k graceful
 {% endif %}

--- a/apache/init.sls
+++ b/apache/init.sls
@@ -18,7 +18,7 @@ apache-reload:
     - m_name: {{ apache.service }}
 {% else %}
     - name: cmd.run
-    - cmd: "ps -ef | grep {{ apache.service }} | grep -v grep && {{ apache.service }} -k graceful"
+    - cmd: "ps -ef | grep {{ apache.server }} | grep -v grep && {{ apache.service }} -k graceful"
     - python_shell: True
 {% endif %}
 
@@ -33,6 +33,6 @@ apache-restart:
 # cluster manager like Pacemaker
   module.wait:
     - name: cmd.run
-    - cmd: "ps -ef | grep {{ apache.service }} | grep -v grep && {{ apache.service }} -k graceful"
+    - cmd: "ps -ef | grep {{ apache.server }} | grep -v grep && {{ apache.service }} -k graceful"
     - python_shell: True
 {% endif %}

--- a/apache/manage_security.sls
+++ b/apache/manage_security.sls
@@ -17,6 +17,10 @@ apache_security-block:
       - pkg: apache
     - watch_in:
       - module: apache-reload
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% for option, value in salt['pillar.get']('apache:security', {}).items() %}
 apache_manage-security-{{ option }}:

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -1,6 +1,7 @@
 {% import_yaml "apache/osfingermap.yaml" as osfingermap %}
+{% import_yaml "apache/defaults.yaml" as apache %}
 
-{% set apache = salt['grains.filter_by']({
+{% set os_apache = salt['grains.filter_by']({
     'Debian': {
         'server': 'apache2',
         'service': 'apache2',
@@ -116,3 +117,5 @@
 }, grain='oscodename', merge=salt['grains.filter_by'](
     osfingermap
 , grain='osfinger', merge=salt['pillar.get']('apache:lookup')))) %}
+
+{% do apache.update(os_apache) %}

--- a/apache/mod_actions.sls
+++ b/apache/mod_actions.sls
@@ -11,5 +11,9 @@ a2enmod actions:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/mod_dav_svn.sls
+++ b/apache/mod_dav_svn.sls
@@ -16,6 +16,10 @@ a2enmod dav_svn:
       - pkg: libapache2-mod-svn
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 a2enmod authz_svn:
   cmd.run:
@@ -26,5 +30,9 @@ a2enmod authz_svn:
       - pkg: libapache2-mod-svn
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/mod_fcgid.sls
+++ b/apache/mod_fcgid.sls
@@ -19,5 +19,9 @@ a2enmod fcgid:
       - pkg: mod-fcgid
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/mod_headers.sls
+++ b/apache/mod_headers.sls
@@ -11,5 +11,9 @@ a2enmod headers:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/mod_mpm.sls
+++ b/apache/mod_mpm.sls
@@ -12,6 +12,10 @@ a2enmod {{ mpm_module }}:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
   file.managed:
     - name: /etc/apache2/mods-available/{{ mpm_module }}.conf
     - template: jinja
@@ -21,6 +25,10 @@ a2enmod {{ mpm_module }}:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 # Deactivate the other mpm modules as a previous step
 {% for mod in ['mpm_prefork', 'mpm_worker', 'mpm_event'] if not mod == mpm_module %}
@@ -29,10 +37,13 @@ a2dismod {{ mod }}:
     - onlyif: test -e /etc/apache2/mods-enabled/{{ mod }}.load
     - require:
       - pkg: apache
-    - require_in:
-      - cmd: a2enmod {{ mpm_module }}
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - cmd: a2enmod {{ mpm_module }}
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 {% endfor %}
 
 {% endif %}

--- a/apache/mod_pagespeed.sls
+++ b/apache/mod_pagespeed.sls
@@ -17,7 +17,7 @@ a2enmod pagespeed:
     - require:
       - pkg: libapache2-mod-pagespeed
     - watch_in:
-      - service: apache
+      - module: apache-restart
 
 {% for dir in ['/var/cache/mod_pagespeed', '/var/log/pagespeed'] %}
 {{ dir }}:

--- a/apache/mod_pagespeed.sls
+++ b/apache/mod_pagespeed.sls
@@ -18,6 +18,10 @@ a2enmod pagespeed:
       - pkg: libapache2-mod-pagespeed
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% for dir in ['/var/cache/mod_pagespeed', '/var/log/pagespeed'] %}
 {{ dir }}:

--- a/apache/mod_php5.sls
+++ b/apache/mod_php5.sls
@@ -19,6 +19,10 @@ a2enmod php5:
       - pkg: mod-php5
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% if 'apache' in pillar and 'php-ini' in pillar['apache'] %}
 /etc/php5/apache2/php.ini:
@@ -27,6 +31,10 @@ a2enmod php5:
     - order: 225
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
     - require:
       - pkg: apache
       - pkg: mod-php5

--- a/apache/mod_proxy.sls
+++ b/apache/mod_proxy.sls
@@ -12,5 +12,9 @@ a2enmod mod_proxy:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/mod_proxy_http.sls
+++ b/apache/mod_proxy_http.sls
@@ -13,5 +13,9 @@ a2enmod proxy_http:
       - cmd: a2enmod proxy
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/mod_remoteip.sls
+++ b/apache/mod_remoteip.sls
@@ -20,6 +20,6 @@ a2enmod remoteip:
     - require:
       - pkg: apache
     - watch_in:
-      - service: apache
+      - module: apache-restart
 
 {% endif %}

--- a/apache/mod_remoteip.sls
+++ b/apache/mod_remoteip.sls
@@ -11,6 +11,10 @@ a2enmod remoteip:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 /etc/apache2/conf-available/remoteip.conf:
   file.managed:
@@ -21,5 +25,9 @@ a2enmod remoteip:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/mod_rewrite.sls
+++ b/apache/mod_rewrite.sls
@@ -11,5 +11,9 @@ a2enmod rewrite:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -8,6 +8,10 @@ pkg_mod_ssl:
     - name: mod_ssl
     - watch_in:
       - module: apache-reload
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 file_mod_ssl:
   file.managed:
     - name: /etc/httpd/conf.d/ssl.conf
@@ -18,6 +22,10 @@ file_mod_ssl:
     - mode: 0644
     - watch_in:
       - module: apache-reload
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}
 {% if grains['os_family']=="Debian" %}
@@ -30,5 +38,9 @@ a2enmod mod_ssl:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -1,8 +1,26 @@
-{% if grains['os_family']=="Debian" %}
 
 include:
   - apache
 
+{% if grains['os_family']=="RedHat" %}
+pkg_mod_ssl:
+  pkg.installed:
+    - name: mod_ssl
+    - watch_in:
+      - module: apache-reload
+file_mod_ssl:
+  file.managed:
+    - name: /etc/httpd/conf.d/ssl.conf
+    - source: salt://apache/files/RedHat/ssl.conf.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 0644
+    - watch_in:
+      - module: apache-reload
+
+{% endif %}
+{% if grains['os_family']=="Debian" %}
 a2enmod mod_ssl:
   cmd.run:
     - name: a2enmod ssl

--- a/apache/mod_vhost_alias.sls
+++ b/apache/mod_vhost_alias.sls
@@ -11,5 +11,9 @@ a2enmod vhost_alias:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/mod_wsgi.sls
+++ b/apache/mod_wsgi.sls
@@ -8,6 +8,12 @@ mod_wsgi:
     - name: {{ apache.mod_wsgi }}
     - require:
       - pkg: apache
+    - watch_in:
+      - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% if grains.get('os_family') == 'RedHat' and grains.get('osmajorrelease') < 7 %}
 /etc/httpd/conf.d/wsgi.conf:

--- a/apache/mod_wsgi.sls
+++ b/apache/mod_wsgi.sls
@@ -9,10 +9,16 @@ mod_wsgi:
     - require:
       - pkg: apache
 
-{% if grains.get('os_family') == 'RedHat' %}
+{% if grains.get('os_family') == 'RedHat' and grains.get('osmajorrelease') < 7 %}
 /etc/httpd/conf.d/wsgi.conf:
   file.uncomment:
     - regex: LoadModule
     - require:
       - pkg: mod_wsgi
+    - watch_in:
+      - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 {% endif %}

--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -12,6 +12,10 @@ a2enmod {{ module }}:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 {% endfor %}
 
 {% for module in salt['pillar.get']('apache:modules:disabled', []) %}
@@ -23,6 +27,10 @@ a2dismod {{ module }}:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 {% endfor %}
 
 {% elif grains['os_family']=="RedHat" %}
@@ -39,6 +47,10 @@ find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(\s*LoadModule
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 {% endfor %}
 
 {% for module in salt['pillar.get']('apache:modules:disabled', []) %}
@@ -50,6 +62,10 @@ find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^\s*LoadModule.{{ m
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 {% endfor %}
 
 {% endif %}

--- a/apache/no_default_vhost.sls
+++ b/apache/no_default_vhost.sls
@@ -12,5 +12,9 @@ apache_no-default-vhost:
       - pkg: apache
     - watch_in:
       - module: apache-reload
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/orchestration/init.sls
+++ b/apache/orchestration/init.sls
@@ -1,0 +1,21 @@
+#!jinja|yaml
+{% set node_ids = salt['pillar.get']('apache:lookup:pcs:node_ids') -%}
+{% set admin_node_id = salt['pillar.get']('apache:lookup:pcs:admin_node_id') -%}
+
+# node_ids: {{node_ids|json}}
+# admin_node_id: {{admin_node_id}}
+
+apache_orchestration__install:
+  salt.state:
+    - tgt: {{node_ids|json}}
+    - tgt_type: list
+    - expect_minions: True
+    - sls: apache.server_status
+
+apache_orchestration__pcs:
+  salt.state:
+    - tgt: {{admin_node_id}}
+    - expect_minions: True
+    - sls: apache.pcs
+    - require:
+      - salt: apache_orchestration__install

--- a/apache/own_default_vhost.sls
+++ b/apache/own_default_vhost.sls
@@ -13,5 +13,9 @@ apache_own-default-vhost:
       - pkg: apache
     - watch_in:
       - module: apache-reload
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}

--- a/apache/pcs.sls
+++ b/apache/pcs.sls
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+#FIXME
+{# from "apache/map.jinja" import apache with context #}
+
+{% set apache = salt['pillar.get']('apache:lookup:pcs', {}) %}
+
+{% if apache.apache_cib is defined and apache.apache_cib %}
+apache_pcs__cib_present_{{apache.apache_cib}}:
+  pcs.cib_present:
+    - cibname: {{apache.apache_cib}}
+{% endif %}
+
+{% if 'resources' in apache %}
+{% for resource, resource_data in apache.resources.items()|sort %}
+apache_pcs__resource_present_{{resource}}:
+  pcs.resource_present:
+    - resource_id: {{resource}}
+    - resource_type: "{{resource_data.resource_type}}"
+    - resource_options: {{resource_data.resource_options|json}}
+{% if apache.apache_cib is defined and apache.apache_cib %}
+    - require:
+      - pcs: apache_pcs__cib_present_{{apache.apache_cib}}
+    - require_in:
+      - pcs: apache_pcs__cib_pushed_{{apache.apache_cib}}
+    - cibname: {{apache.apache_cib}}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if 'constraints' in apache %}
+{% for constraint, constraint_data in apache.constraints.items()|sort %}
+apache_pcs__constraint_present_{{constraint}}:
+  pcs.constraint_present:
+    - constraint_id: {{constraint}}
+    - constraint_type: "{{constraint_data.constraint_type}}"
+    - constraint_options: {{constraint_data.constraint_options|json}}
+{% if apache.apache_cib is defined and apache.apache_cib %}
+    - require:
+      - pcs: apache_pcs__cib_present_{{apache.apache_cib}}
+    - require_in:
+      - pcs: apache_pcs__cib_pushed_{{apache.apache_cib}}
+    - cibname: {{apache.apache_cib}}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if apache.apache_cib is defined and apache.apache_cib %}
+apache_pcs__cib_pushed_{{apache.apache_cib}}:
+  pcs.cib_pushed:
+    - cibname: {{apache.apache_cib}}
+{% endif %}

--- a/apache/pcs.sls
+++ b/apache/pcs.sls
@@ -51,3 +51,8 @@ apache_pcs__cib_pushed_{{apache.apache_cib}}:
   pcs.cib_pushed:
     - cibname: {{apache.apache_cib}}
 {% endif %}
+
+apache_pcs__empty_sls_prevent_error:
+  cmd.run:
+    - name: true
+    - unless: true

--- a/apache/register_site.sls
+++ b/apache/register_site.sls
@@ -49,6 +49,10 @@
     - watch_in:
       - cmd: {{ a2modid }}
       - module: apache-reload
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% endif %}
 ##########################################

--- a/apache/server_status.sls
+++ b/apache/server_status.sls
@@ -11,3 +11,7 @@ include:
       - pkg: apache
     - watch_in:
       - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache

--- a/apache/server_status.sls
+++ b/apache/server_status.sls
@@ -1,0 +1,13 @@
+{% from "apache/map.jinja" import apache with context %}
+
+include:
+  - apache
+  - apache.config
+
+{{apache.confdir}}/server-status{{apache.confext}}:
+  file.managed:
+    - source: salt://apache/files/server-status.conf
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart

--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -21,6 +21,10 @@ include:
       - pkg: apache
     - watch_in:
       - module: apache-reload
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 
 {% if site.get('DocumentRoot') != False %}
 {{ id }}-documentroot:
@@ -41,6 +45,10 @@ a2ensite {{ id }}{{ apache.confext }}:
       - file: /etc/apache2/sites-available/{{ id }}{{ apache.confext }}
     - watch_in:
       - module: apache-reload
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 {% else %}
 a2dissite {{ id }}{{ apache.confext }}:
   cmd:
@@ -50,6 +58,10 @@ a2dissite {{ id }}{{ apache.confext }}:
       - file: /etc/apache2/sites-available/{{ id }}{{ apache.confext }}
     - watch_in:
       - module: apache-reload
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
 {% endif %}
 {% endif %}
 

--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -3,6 +3,7 @@
 {%- set sitename = site.get('ServerName', id) -%}
 
 {%- set vals = {
+    'listens': site.get('listen', '*:80').split(),
     'interfaces': site.get('interface', '*').split(),
     'port': site.get('port', '80'),
 
@@ -37,7 +38,11 @@
         'Require': 'all granted',
     },
 } -%}
-
+{%- if site.get('listen') %}
+{%- for listen in vals.listens %}
+Listen {{ listen }}
+{%- endfor %}
+{%- endif %}
 <VirtualHost {% for intf in vals.interfaces %} {{intf}}:{{ vals.port }}{% endfor -%}>
     ServerName {{ vals.ServerName }}
     {% if site.get('ServerAlias') != False %}ServerAlias {{ vals.ServerAlias }}{% endif %}

--- a/pillar_cluster.example
+++ b/pillar_cluster.example
@@ -1,0 +1,81 @@
+# on master node load this pillar for calling the salt apache orchestration state
+apache:
+  lookup:
+    pcs:
+      node_ids: 
+        - node1.example.org
+        - node2.example.org
+        - node3.example.org
+      admin_node_id: node1.example.org
+
+# on minions load this pillar
+apache:
+  lookup:
+    # service must be disabled, because it's managed by Pacemaker
+    service_state: disabled
+    service_enable: False
+    # name conventions for resources match  pcs setting below
+    custom_reload_command: pcs resource show apache && (pcs resource cleanup apache && sleep 5 && pcs resource debug-start apache|grep "apache already running" && pcs resource restart apache-clone) || true
+    custom_restart_command: pcs resource show apache && (pcs resource cleanup apache && sleep 5 && pcs resource debug-start apache|grep "apache already running" && pcs resource restart apache-clone) || true
+
+    #with this settings apache listens on localhost:80 for http traffic only
+    standard_listen_directive: localhost:80
+    standard_listen_directive_ssl: False
+
+    pcs:
+      apache_cib: cib_for_apache
+      resources:
+        apache:
+          resource_type: "apache"
+          resource_options:
+            - "--clone"
+            - "interleave=true"
+
+      constraints:
+        # For keystone wsgi
+        #pcs constraint order start haproxy-clone then apache-clone
+        order-haproxy-clone-apache-clone-Optional:
+          constraint_type: "order"
+          constraint_options:
+            - "start"
+            - "haproxy-clone"
+            - "then"
+            - "apache-clone"
+            - "kind=Optional"
+
+        #pcs constraint order start rabbitmq-clone then apache-clone
+        order-rabbitmq-clone-apache-clone-Optional:
+          constraint_type: "order"
+          constraint_options:
+            - "start"
+            - "rabbitmq-clone"
+            - "then"
+            - "apache-clone"
+            - "kind=Optional"
+
+        #pcs constraint order start memcached-clone then apache-clone
+        order-memcached-clone-apache-clone-Optional:
+          constraint_type: "order"
+          constraint_options:
+            - "start"
+            - "memcached-clone"
+            - "then"
+            - "apache-clone"
+            - "kind=Optional"
+
+        #pcs constraint order promote galera-master then apache-clone
+        order-galera-master-apache-clone-mandatory:
+          constraint_type: "order"
+          constraint_options:
+            - "promote"
+            - "galera-master"
+            - "then"
+            - "apache-clone"
+            - "kind=Mandatory"
+
+  sites:
+    mysite.example.org:
+      template_file: salt://apache/vhosts/standard.tmpl
+      listen: "192.168.1.101:80 192.168.2.101:80"
+      interface: "192.168.1.101 192.168.2.101"
+      port: "80"


### PR DESCRIPTION
**Summary of Changes**
- Issue summary:
  - multiple commits for rhel (7) 
  - use watch module: apache-[restart|reload] consequently
  - make Listen more modular 
  - mod_ssl for rhel
  - server-status state(for clusters like Pacemaker)
  - pcs state for creating Pacemaker cluster resources with PCS.
  - make service more modular (allow it to be disabled if apache is manageg by clusters like Pacemaker)
  - defaults.yaml
  - orchestration state to deploy apache on a pacemaker cluster (requires salt pcs module and state-module from salt development branch)

**Testing**
- Tested on OS 

Changes should all be backward compatible.
