### PR TITLE
RedHat: Added configurable variables, Fixed bug if vhostdir is something diff…

### DIFF
--- a/apache/files/RedHat/apache-2.4.config.jinja
+++ b/apache/files/RedHat/apache-2.4.config.jinja
@@ -1,3 +1,4 @@
+{% from "apache/map.jinja" import apache with context %}
 #
 # This is the main Apache HTTP server configuration file.  It contains the
 # configuration directives that give the server its instructions.
@@ -116,7 +117,7 @@ ServerAdmin root@localhost
 # documents. By default, all requests are taken from this directory, but
 # symbolic links and aliases may be used to point to other locations.
 #
-DocumentRoot "/var/www/html"
+DocumentRoot "{{ apache.wwwdir }}"
 
 #
 # Relax access to content within /var/www.
@@ -128,7 +129,7 @@ DocumentRoot "/var/www/html"
 </Directory>
 
 # Further relax access to the default document root:
-<Directory "/var/www/html">
+<Directory "{{ apache.wwwdir }}">
     #
     # Possible values for the Options directive are "None", "All",
     # or any combination of:
@@ -179,7 +180,7 @@ DocumentRoot "/var/www/html"
 # logged here.  If you *do* define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
 #
-ErrorLog "logs/error_log"
+ErrorLog "{{ apache.logdir }}/error_log"
 
 #
 # LogLevel: Control the number of messages logged to the error_log.
@@ -217,7 +218,7 @@ LogLevel warn
     # If you prefer a logfile with access, agent, and referer information
     # (Combined Logfile Format) you can use the following directive.
     #
-    CustomLog "logs/access_log" combined
+    CustomLog "{{ apache.logdir }}/access_log" combined
 </IfModule>
 
 <IfModule alias_module>
@@ -357,5 +358,8 @@ EnableSendfile on
 # Supplemental configuration
 #
 # Load config files in the "/etc/httpd/conf.d" directory, if any.
-IncludeOptional conf.d/*.conf
-IncludeOptional vhosts.d/*.conf
+IncludeOptional {{ apache.confdir }}/*.conf
+{% if apache.vhostdir != apache.confdir %}
+IncludeOptional {{ apache.vhostdir }}/*.conf
+{% endif %}
+


### PR DESCRIPTION
**Fixed a bug and made RH config file more flexible**
 * Fixed vhostdir bug 
   - IncludeOptional statement for vhostdir was hardcoded resulting in Apache config error if apache.vhostdir pillar set to different value than default
 * Made config file more flexible
   - Added configuration variables from map.jinja to RedHat Apache 2.4 config file
**Testing**
 - Tested on CentOS 7