### PR TITLE
enable mod_ssl on Redhat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,11 @@ using data from Pillar. (Debian and RedHat Only)
 
 Allows you to install the basic Core Rules (CRS) and some basic configuration for mod_security2
 
+``apache.mod_ssl``
+----------------------
+
+Installs and enables the mod_ssl module (Debian and RedHad only)
+
 ``apache.mod_vhost_alias``
 ----------------------
 

--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -13,4 +13,13 @@ a2enmod mod_ssl:
     - watch_in:
       - module: apache-restart
 
+{% elif grains['os_family']=="RedHat" %}
+
+mod_ssl:
+  pkg.installed:
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+
 {% endif %}


### PR DESCRIPTION
**Summary of Changes**
 -  mod_ssl rpm is required on RedHat.  Added to apache.mod_ssl state.
 - added the module description to README.rst
 
**Testing**
 - Tested on OEL7

