### PR TITLE
Proper disabling of the default vhost

### DIFF
--- a/apache/no_default_vhost.sls
+++ b/apache/no_default_vhost.sls
@@ -5,9 +5,10 @@
 include:
   - apache
 
-apache_no-default-vhost:
-  file.absent:
-    - name: {{ apache.vhostdir }}/000-default.conf
+a2dissite 000-default.conf:
+  cmd:
+    - run
+    - unless: test ! -f /etc/apache2/sites-enabled/000-default.conf
     - require:
       - pkg: apache
     - watch_in:

--- a/apache/no_default_vhost.sls
+++ b/apache/no_default_vhost.sls
@@ -6,8 +6,7 @@ include:
   - apache
 
 a2dissite 000-default.conf:
-  cmd:
-    - run
+  cmd.run:
     - unless: test ! -f /etc/apache2/sites-enabled/000-default.conf
     - require:
       - pkg: apache

--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -34,8 +34,7 @@ include:
 {% if grains.os_family == 'Debian' %}
 {% if site.get('enabled', True) %}
 a2ensite {{ id }}{{ apache.confext }}:
-  cmd:
-    - run
+  cmd.run:
     - unless: test -f /etc/apache2/sites-enabled/{{ id }}{{ apache.confext }}
     - require:
       - file: /etc/apache2/sites-available/{{ id }}{{ apache.confext }}
@@ -43,8 +42,7 @@ a2ensite {{ id }}{{ apache.confext }}:
       - module: apache-reload
 {% else %}
 a2dissite {{ id }}{{ apache.confext }}:
-  cmd:
-    - run
+  cmd.run:
     - onlyif: test -f /etc/apache2/sites-enabled/{{ id }}{{ apache.confext }}
     - require:
       - file: /etc/apache2/sites-available/{{ id }}{{ apache.confext }}


### PR DESCRIPTION
Removing the file /etc/apache2/sites-available/000-default.conf leads to an error when Apache is restarted.
So the symlink in /etc/apache2/sites-enabled/ should be removed, the actual file can stay.

 - Tested in Vagrant on Debian Jessie
