### PR TITLE
[#141] Support additional options for Proxypass

### DIFF
--- a/apache/vhosts/proxy.tmpl
+++ b/apache/vhosts/proxy.tmpl
@@ -50,11 +50,12 @@
     {% set proxyvals = {
         'ProxyPassSource': proxyargs.get('ProxyPassSource', '/'),
         'ProxyPassTarget': proxyargs.get('ProxyPassTarget', 'https://{0}'.format(sitename)),
+        'ProxyPassTargetOptions': proxyargs.get('ProxyPassTargetOptions', ''),
         'ProxyPassReverseSource': proxyargs.get('ProxyPassReverseSource', '/'),
         'ProxyPassReverseTarget': proxyargs.get('ProxyPassReverseTarget', site.get('ProxyPassTarget', 'https://{0}'.format(sitename))),
     } %}
     ######### {{proxy}} #########
-    ProxyPass               {{ proxyvals.ProxyPassSource }} {{ proxyvals.ProxyPassTarget }}
+    ProxyPass               {{ proxyvals.ProxyPassSource }} {{ proxyvals.ProxyPassTarget }} {{ proxyvals.ProxyPassTargetOptions }}
     ProxyPassReverse        {{ proxyvals.ProxyPassReverseSource }} {{ proxyvals.ProxyPassReverseTarget }}
     {% endfor %}
     {% if site.get('Formula_Append') %}

--- a/pillar.example
+++ b/pillar.example
@@ -90,6 +90,7 @@ apache:
       #   my sample route:
       #      ProxyPassSource: '/'
       #      ProxyPassTarget: 'http://www.example.net'
+      #      ProxyPassTargetOptions: 'connectiontimeout=5 timeout=30'
       #      ProxyPassReverseSource: '/'
       #      ProxyPassReverseTarget: 'http://www.example.net'
 


### PR DESCRIPTION
Ref: Please support additional options for Proxypass #141 

**Summary of Changes**
* It would be great if the ProxyPass option supported addtional options e.g by using something like ProxyPassTargetOptions.:
 - `ProxyPassTargetOptions: "connectiontimeout=5 timeout=30"`to give the following:
   - `ProxyPass "/example" "http://backend.example.com" connectiontimeout=5 timeout=30`

This PR has been written with the following narrative:
* I would like to:
  * Add extra options to the proxy pass target
  * Put an example of how the `ProxyPassTargetOptions` is used.

**Testing**
 - Tested on Centos 6.5 