### PR TITLE
Add '-f' option to a2dismod to fix hanging minions for some modules

### DIFF
--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -15,7 +15,7 @@ a2enmod {{ module }}:
 {% endfor %}
 
 {% for module in salt['pillar.get']('apache:modules:disabled', []) %}
-a2dismod {{ module }}:
+a2dismod -f {{ module }}:
   cmd.run:
     - onlyif: ls /etc/apache2/mods-enabled/{{ module }}.load
     - order: 225


### PR DESCRIPTION
Since jessie(?) a2dismod needs '-f' option to disable some modules which it thinks are 'basic' without asking the user.

Please merge so this state will work in Debian Jessie

