### PR TITLE
Add proxyrequests directive

### DIFF
--- a/apache/vhosts/proxy.tmpl
+++ b/apache/vhosts/proxy.tmpl
@@ -18,6 +18,7 @@
     'LogFormat': site.get('LogFormat', '"%h %l %u %t \\\"%r\\\" %>s %O"'),
     'CustomLog': site.get('CustomLog', '{0}/{1}-access.log'.format(map.logdir, sitename)),
     
+    'ProxyRequests': site.get('ProxyRequests', 'Off'),
     'ProxyPreserveHost': site.get('ProxyPreserveHost', 'On'),
     'ProxyRoute': site.get('ProxyRoute', {}),
 } %}
@@ -44,7 +45,7 @@
     SSLCertificateChainFile {{ site.SSLCertificateChainFile}}
     {%   endif %}
     {% endif %}
-
+    ProxyRequests {{ vals.ProxyRequests }}
     ProxyPreserveHost {{ vals.ProxyPreserveHost }}    
     {% for proxy, proxyargs in vals.ProxyRoute|dictsort|reverse %}
     {% set proxyvals = {

--- a/pillar.example
+++ b/pillar.example
@@ -85,6 +85,7 @@ apache:
       # RedirectTarget: 'http://www.example.net'
 
       # if template is 'proxy.tmpl'
+      # ProxyRequests: 'On'
       # ProxyPreserveHost: 'On'
       # ProxyRoute:
       #   my sample route:


### PR DESCRIPTION
**Summary of Changes**
 * I am currently in the process of migrating existing apache configurations from a legacy configuration and noticed that the [ProxyRequests Directive](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyrequests) is not supported by this formula so I've implemented it.

**How to Review This PR**

This PR has been written with the following narrative:

I would like to:
 - Add ProxyRequests directive
 - Add example pillar usage

**Testing**
 - Tested on Red Hat Enterprise Server release 6.6 (Santiago)  