### PR TITLE
Do not force usage of apache.config in apache.vhosts.standard

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -2,7 +2,6 @@
 
 include:
   - apache
-  - apache.config
 
 {% for id, site in salt['pillar.get']('apache:sites', {}).items() %}
 {% set documentroot = site.get('DocumentRoot', '{0}/{1}'.format(apache.wwwdir, id)) %}


### PR DESCRIPTION
In 4d04d95b02df334c5e33e06e9dca139a223441f0 (#113) apache/vhosts/standard.sls has been modified by @genuss to include apache.config on the basis that apache.config was now able to retrieve the interfaces/ports from pillar data in apache:sites.

I use apache:sites to register virtual hosts with non-standard "template_file" (they contain the desired configuration directly) and the "interface/port" keys are thus not meaningful.

```
apache:
  sites:
    example.com:
      template_file: salt://vm/example/apache-vhost.conf
      DocumentRoot: False
```

The generated ports.conf ends up containing only "*:80" while my virtual host configuration files need ports 80 and 443. The situation was perfectly fine up to now because the default configuration file handles both of those ports if you have mod_ssl installed.

People who want to use apache.config should just explicitly include that state, we should not force its usage to all apache.vhosts.standard users.