### PR TITLE
RedHat: Made AddDefaultCharset Directive configurable

### DIFF
--- a/apache/files/RedHat/apache-2.4.config.jinja
+++ b/apache/files/RedHat/apache-2.4.config.jinja
@@ -345,7 +345,7 @@ LogLevel warn
 # in HTML content to override this choice, comment out this
 # directive:
 #
-AddDefaultCharset UTF-8
+AddDefaultCharset {{ apache.default_charset }}
 
 <IfModule mime_magic_module>
     #

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -40,6 +40,7 @@
         'logdir': '/var/log/httpd',
         'logrotatedir': '/etc/logrotate.d/httpd',
         'wwwdir': '/var/www',
+        'default_charset': 'UTF-8',
         'use_require': False,
     },
     'Suse': {

--- a/pillar.example
+++ b/pillar.example
@@ -18,6 +18,8 @@ apache:
     # ``apache.mod_wsgi`` formula additional configuration:
     mod_wsgi: mod_wsgi
 
+    # Default value for AddDefaultCharset in RedHat configuration
+    default_charset: 'UTF-8'
 
   global:
     # global apache directives


### PR DESCRIPTION
 
* Made AddDefaultCharset directive more flexible by adding configurable variable default_charset on RedHat derivates 
 - if pillar apache:lookup:default_charset is not set default value remains UTF-8

**Testing**
 - Tested on CentOS in a vagrant environment with different and default value

