### PR TITLE
Set use_require on Ubuntu 16.04 (Xenial Xerus) with Apache 2.4

### DIFF
--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -107,6 +107,12 @@
         'default_site_ssl': 'default-ssl.conf',
         'use_require': True,
     },
+    'xenial': {
+        'confext': '.conf',
+        'default_site': '000-default.conf',
+        'default_site_ssl': 'default-ssl.conf',
+        'use_require': True,
+    },
     'jessie': {
         'wwwdir': '/var/www',
         'confext': '.conf',


### PR DESCRIPTION
Ubuntu 16.04 LTS Xenial Xerus has Apache 2.4 and also needs "require" statements.