### PR TITLE
Adding exclude_listen_directive option

### DIFF
--- a/apache/files/Debian/ports-2.2.conf.jinja
+++ b/apache/files/Debian/ports-2.2.conf.jinja
@@ -8,9 +8,11 @@
         {%- set interfaces = site.get('interface', '*').split() %}
         {%- set port = site.get('port', 80) %}
         {%- for interface in interfaces %}
-            {%- set listen_directive = interface ~ ':' ~ port %}
-            {%- if listen_directive not in listen_directives %}
-                {%- do listen_directives.append(listen_directive) %}
+            {%- if not site.get('exclude_listen_directive', False) %}
+                {%- set listen_directive = interface ~ ':' ~ port %}
+                {%- if listen_directive not in listen_directives %}
+                    {%- do listen_directives.append(listen_directive) %}
+                {%- endif %}
             {%- endif %}
         {%- endfor %}
     {%- endfor %}

--- a/apache/files/Debian/ports-2.4.conf.jinja
+++ b/apache/files/Debian/ports-2.4.conf.jinja
@@ -8,9 +8,11 @@
         {%- set interfaces = site.get('interface', '*').split() %}
         {%- set port = site.get('port', 80) %}
         {%- for interface in interfaces %}
-            {%- set listen_directive = interface ~ ':' ~ port %}
-            {%- if listen_directive not in listen_directives %}
-                {%- do listen_directives.append(listen_directive) %}
+            {%- if not site.get('exclude_listen_directive', False) %}
+                {%- set listen_directive = interface ~ ':' ~ port %}
+                {%- if listen_directive not in listen_directives %}
+                    {%- do listen_directives.append(listen_directive) %}
+                {%- endif %}
             {%- endif %}
         {%- endfor %}
     {%- endfor %}

--- a/apache/files/RedHat/apache-2.4.config.jinja
+++ b/apache/files/RedHat/apache-2.4.config.jinja
@@ -49,9 +49,11 @@ ServerRoot "/etc/httpd"
         {%- set interfaces = site.get('interface', '*').split() %}
         {%- set port = site.get('port', 80) %}
         {%- for interface in interfaces %}
-            {%- set listen_directive = interface ~ ':' ~ port %}
-            {%- if listen_directive not in listen_directives %}
-                {%- do listen_directives.append(listen_directive) %}
+            {%- if not site.get('exclude_listen_directive', False) %}
+                {%- set listen_directive = interface ~ ':' ~ port %}
+                {%- if listen_directive not in listen_directives %}
+                    {%- do listen_directives.append(listen_directive) %}
+                {%- endif %}
             {%- endif %}
         {%- endfor %}
     {%- endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -54,6 +54,8 @@ apache:
       interface: '*'
       port: '80'
 
+      exclude_listen_directive: True # Do not add a Listen directive in httpd.conf
+
       ServerName: example.com # uses the unique ID above unless specified
       ServerAlias: www.example.com
 


### PR DESCRIPTION
Adding an additional option to inhibit creation of a Listen directive in the Apache configuration.
Fixes #150 
