### PR TITLE
Update Debian mpm_prefork.conf to include ServerLimit

### DIFF
--- a/apache/files/Debian/mpm/mpm_prefork.conf.jinja
+++ b/apache/files/Debian/mpm/mpm_prefork.conf.jinja
@@ -5,6 +5,7 @@
 # prefork MPM
 # StartServers: number of server processes to start
 # MinSpareServers: minimum number of server processes which are kept spare
+# ServerLimit: maximum number of server processes
 # MaxSpareServers: maximum number of server processes which are kept spare
 # MaxRequestWorkers: maximum number of server processes allowed to start
 # MaxConnectionsPerChild: maximum number of requests a server process serves
@@ -12,6 +13,9 @@
 <IfModule mpm_prefork_module>
 	StartServers {{ mpm_param['start_servers'] | d('5') }}
 	MaxRequestWorkers {{ mpm_param['max_request_workers'] | d('150') }}
+{%- if mpm_param['max_request_workers'] | d('150') >= 256 %}
+	ServerLimit {{ mpm_param['max_request_workers'] | d('150') }}
+{%- endif %}
 	MinSpareServers {{ mpm_param['min_spare_servers'] | d('5') }}
 	MaxSpareServers {{ mpm_param['max_spare_servers'] | d('10') }}
 	MaxConnectionsPerChild {{ mpm_param['max_connections_per_child'] | d('0') }}


### PR DESCRIPTION
**Summary of Changes**
 * If MaxRequestWorkers is > 256 then ServerLimit needs to be set as it defaults to 256 with a compiled hard limit of 20000 per [Apache docs](https://httpd.apache.org/docs/current/mod/mpm_common.html#serverlimit)
 - Add ServerLimit to simply duplicate MaxRequestWorkers value if it is >= 255
 - Only changes Debian osfamily mpm_prefork.conf file

**Testing**
 - Ran `apache.mod_mpm` state
 - Tested in Vagrant & AWS
 - Tested on Ubuntu 14.04 LTS