### PR TITLE
Correct ProxyPassTarget default for ProxyPassReverseTarget

### DIFF
--- a/apache/vhosts/proxy.tmpl
+++ b/apache/vhosts/proxy.tmpl
@@ -53,7 +53,7 @@
         'ProxyPassTarget': proxyargs.get('ProxyPassTarget', 'https://{0}'.format(sitename)),
         'ProxyPassTargetOptions': proxyargs.get('ProxyPassTargetOptions', ''),
         'ProxyPassReverseSource': proxyargs.get('ProxyPassReverseSource', '/'),
-        'ProxyPassReverseTarget': proxyargs.get('ProxyPassReverseTarget', site.get('ProxyPassTarget', 'https://{0}'.format(sitename))),
+        'ProxyPassReverseTarget': proxyargs.get('ProxyPassReverseTarget', proxyargs.get('ProxyPassTarget', 'https://{0}'.format(sitename))),
     } %}
     ######### {{proxy}} #########
     ProxyPass               {{ proxyvals.ProxyPassSource }} {{ proxyvals.ProxyPassTarget }} {{ proxyvals.ProxyPassTargetOptions }}


### PR DESCRIPTION
According to the pillar.example file there is no `site.ProxyPassTarget`, so `ProxyPassReverseTarget` should default to `proxyargs.ProxyPassTarget` (ie. `site.ProxyRoute.ProxyPassTarget`)