### PR TITLE
FreeBSD support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,11 @@ Installs and enables the mod_perl2 module (Debian and FreeBSD only)
 
 Installs and enables the mod_php5 module
 
+``apache.mod_cgi``
+---------------------
+
+Enables mod_cgi. (FreeBSD only)
+
 ``apache.mod_fcgid``
 --------------------
 
@@ -114,7 +119,7 @@ Enables mod_socache_shmcb. (FreeBSD only)
 
 Installs and enables the mod_ssl module (Debian, RedHat and FreeBSD only)
 
-``mod_suexec``
+``apache.mod_suexec``
 ---------------------
 
 Enables mod_suexec. (FreeBSD only)

--- a/README.rst
+++ b/README.rst
@@ -94,14 +94,20 @@ using data from Pillar. (Debian and RedHat Only)
 Allows you to install the basic Core Rules (CRS) and some basic configuration for mod_security2
 
 ``apache.mod_security.rules``
+-----------------------------
 
 This state can create symlinks based on basic Core Rules package. (Debian only)
 Or it can distribute a mod_security rule file and place it /etc/modsecurity/
 
+``mod_socache_shmcb``
+---------------------
+
+Enables mod_socache_shmcb. (FreeBSD only)
+
 ``apache.mod_ssl``
 ----------------------
 
-Installs and enables the mod_ssl module (Debian and RedHad only)
+Installs and enables the mod_ssl module (Debian, RedHat and FreeBSD only)
 
 ``apache.mod_vhost_alias``
 ----------------------

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Enabled the Apache module mod_rewrite (Debian only)
 ``apache.mod_proxy``
 -------------------
 
-Enables the Apache module mod_proxy. (Debian only)
+Enables the Apache module mod_proxy. (Debian and FreeBSD only)
 
 ``apache.mod_proxy_http``
 -------------------------

--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,11 @@ Enables mod_socache_shmcb. (FreeBSD only)
 
 Installs and enables the mod_ssl module (Debian, RedHat and FreeBSD only)
 
+``mod_suexec``
+---------------------
+
+Enables mod_suexec. (FreeBSD only)
+
 ``apache.mod_vhost_alias``
 ----------------------
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Enables and disables Apache modules.
 ``apache.mod_rewrite``
 ----------------------
 
-Enabled the Apache module mod_rewrite (Debian only)
+Enabled the Apache module mod_rewrite (Debian and FreeBSD only)
 
 ``apache.mod_proxy``
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,11 @@ Enables the Apache module mod_headers. (Debian Only)
 
 Installs and Enables the mod_pagespeed module. (Debian and RedHat Only)
 
+``apache.mod_perl2``
+-------------------
+
+Installs and enables the mod_perl2 module (Debian and FreeBSD only)
+
 ``apache.mod_php5``
 -------------------
 

--- a/apache/config.sls
+++ b/apache/config.sls
@@ -69,3 +69,17 @@ include:
     - context:
       apache: {{ apache }}
 {% endif %}
+
+{% if grains['os_family']=="FreeBSD" %}
+{{ apache.portsfile }}:
+  file.managed:
+    - template: jinja
+    - source:
+      - salt://apache/files/{{ salt['grains.get']('os_family') }}/ports-{{ apache.version }}.conf.jinja
+    - require:
+      - pkg: apache
+    - watch_in:
+      - service: apache
+    - context:
+      apache: {{ apache }}
+{% endif %}

--- a/apache/config.sls
+++ b/apache/config.sls
@@ -71,6 +71,16 @@ include:
 {% endif %}
 
 {% if grains['os_family']=="FreeBSD" %}
+/usr/local/etc/{{ apache.service }}/envvars.d/by_salt.env:
+  file.managed:
+    - template: jinja
+    - source:
+      - salt://apache/files/{{ salt['grains.get']('os_family') }}/envvars-{{ apache.version }}.jinja
+    - require:
+      - pkg: apache
+    - watch_in:
+      - service: apache
+
 {{ apache.portsfile }}:
   file.managed:
     - template: jinja

--- a/apache/files/Debian/apache-2.2.config.jinja
+++ b/apache/files/Debian/apache-2.2.config.jinja
@@ -227,6 +227,10 @@ LogFormat "%h %l %u %t \"%r\" %>s %O" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 
+{%- for directive, dvalue in salt['pillar.get']('apache:global', {}).items() %}
+{{ directive }} {{ dvalue }}
+{%- endfor %}
+
 # Include of directories ignores editors' and dpkg's backup files,
 # see README.Debian for details.
 

--- a/apache/files/Debian/apache-2.4.config.jinja
+++ b/apache/files/Debian/apache-2.4.config.jinja
@@ -211,6 +211,10 @@ LogFormat "%{User-agent}i" agent
 LogFormat {{ log_format }}
 {%- endfor %}
 
+{%- for directive, dvalue in salt['pillar.get']('apache:global', {}).items() %}
+{{ directive }} {{ dvalue }}
+{%- endfor %}
+
 # Include of directories ignores editors' and dpkg's backup files,
 # see README.Debian for details.
 

--- a/apache/files/FreeBSD/apache-2.4.config.jinja
+++ b/apache/files/FreeBSD/apache-2.4.config.jinja
@@ -519,5 +519,12 @@ SSLRandomSeed startup builtin
 SSLRandomSeed connect builtin
 </IfModule>
 
+# Default Values
+ServerTokens Prod
+ServerSignature Off
+TraceEnable Off
+# Well, IncludeOptional behaved lile Include
+IncludeOptional etc/apache24/extra/security.con[f]
+
 Include etc/apache24/Includes/*.conf
 

--- a/apache/files/FreeBSD/apache-2.4.config.jinja
+++ b/apache/files/FreeBSD/apache-2.4.config.jinja
@@ -230,6 +230,10 @@ ServerAdmin root@localhost
 # below.
 #
 
+{%- for directive, dvalue in salt['pillar.get']('apache:global', {}).items() %}
+{{ directive }} {{ dvalue }}
+{%- endfor %}
+
 {% if apache.global_document_root is defined and apache.global_document_root|length > 0 %}
 #
 # DocumentRoot: The directory out of which you will serve your

--- a/apache/files/FreeBSD/apache-2.4.config.jinja
+++ b/apache/files/FreeBSD/apache-2.4.config.jinja
@@ -40,8 +40,6 @@ ServerRoot "/usr/local"
 #
 # Mutex default:/var/run
 
-Include {{ apache.portsfile }}
-
 #
 # Dynamic Shared Object (DSO) Support
 #
@@ -171,6 +169,8 @@ LoadModule alias_module libexec/apache24/mod_alias.so
 # Third party modules
 IncludeOptional etc/apache24/modules.d/[0-9][0-9][0-9]_*.conf
  
+Include {{ apache.portsfile }}
+
 <IfModule unixd_module>
 #
 # If you wish httpd to run as a different user or group, you must run

--- a/apache/files/FreeBSD/apache-2.4.config.jinja
+++ b/apache/files/FreeBSD/apache-2.4.config.jinja
@@ -230,13 +230,14 @@ ServerAdmin root@localhost
 # below.
 #
 
+{% if apache.global_document_root is defined and apache.global_document_root|length > 0 %}
 #
 # DocumentRoot: The directory out of which you will serve your
 # documents. By default, all requests are taken from this directory, but
 # symbolic links and aliases may be used to point to other locations.
 #
-DocumentRoot "/usr/local/www/apache24/data"
-<Directory "/usr/local/www/apache24/data">
+DocumentRoot "{{ apache.global_document_root }}"
+<Directory "{{ apache.global_document_root }}">
     #
     # Possible values for the Options directive are "None", "All",
     # or any combination of:
@@ -263,6 +264,7 @@ DocumentRoot "/usr/local/www/apache24/data"
     #
     Require all granted
 </Directory>
+{% endif %}
 
 #
 # DirectoryIndex: sets the file that Apache will serve if a directory

--- a/apache/files/FreeBSD/apache-2.4.config.jinja
+++ b/apache/files/FreeBSD/apache-2.4.config.jinja
@@ -358,7 +358,7 @@ LogLevel warn
     # client.  The same rules about trailing "/" apply to ScriptAlias
     # directives as to Alias.
     #
-    ScriptAlias /cgi-bin/ "/usr/local/www/apache24/cgi-bin/"
+    #ScriptAlias /cgi-bin/ "/usr/local/www/apache24/cgi-bin/"
 
 </IfModule>
 

--- a/apache/files/FreeBSD/apache-2.4.config.jinja
+++ b/apache/files/FreeBSD/apache-2.4.config.jinja
@@ -1,0 +1,517 @@
+#
+# This is the main Apache HTTP server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See <URL:http://httpd.apache.org/docs/2.4/> for detailed information.
+# In particular, see 
+# <URL:http://httpd.apache.org/docs/2.4/mod/directives.html>
+# for a discussion of each configuration directive.
+#
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.  
+#
+# Configuration and logfile names: If the filenames you specify for many
+# of the server's control files begin with "/" (or "drive:/" for Win32), the
+# server will use that explicit path.  If the filenames do *not* begin
+# with "/", the value of ServerRoot is prepended -- so "logs/access_log"
+# with ServerRoot set to "/usr/local/apache2" will be interpreted by the
+# server as "/usr/local/apache2/logs/access_log", whereas "/logs/access_log" 
+# will be interpreted as '/logs/access_log'.
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# Do not add a slash at the end of the directory path.  If you point
+# ServerRoot at a non-local disk, be sure to specify a local disk on the
+# Mutex directive, if file-based mutexes are used.  If you wish to share the
+# same ServerRoot for multiple httpd daemons, you will need to change at
+# least PidFile.
+#
+ServerRoot "/usr/local"
+
+#
+# Mutex: Allows you to set the mutex mechanism and mutex file directory
+# for individual mutexes, or change the global defaults
+#
+# Uncomment and change the directory if mutexes are file-based and the default
+# mutex file directory is not on a local disk or is not appropriate for some
+# other reason.
+#
+# Mutex default:/var/run
+
+Include {{ apache.portsfile }}
+
+#
+# Dynamic Shared Object (DSO) Support
+#
+# To be able to use the functionality of a module which was built as a DSO you
+# have to place corresponding `LoadModule' lines at this location so the
+# directives contained in it are actually available _before_ they are used.
+# Statically compiled modules (those listed by `httpd -l') do not need
+# to be loaded here.
+#
+# Example:
+# LoadModule foo_module modules/mod_foo.so
+#
+LoadModule authn_file_module libexec/apache24/mod_authn_file.so
+#LoadModule authn_dbm_module libexec/apache24/mod_authn_dbm.so
+#LoadModule authn_anon_module libexec/apache24/mod_authn_anon.so
+#LoadModule authn_dbd_module libexec/apache24/mod_authn_dbd.so
+#LoadModule authn_socache_module libexec/apache24/mod_authn_socache.so
+LoadModule authn_core_module libexec/apache24/mod_authn_core.so
+LoadModule authz_host_module libexec/apache24/mod_authz_host.so
+LoadModule authz_groupfile_module libexec/apache24/mod_authz_groupfile.so
+LoadModule authz_user_module libexec/apache24/mod_authz_user.so
+#LoadModule authz_dbm_module libexec/apache24/mod_authz_dbm.so
+#LoadModule authz_owner_module libexec/apache24/mod_authz_owner.so
+#LoadModule authz_dbd_module libexec/apache24/mod_authz_dbd.so
+LoadModule authz_core_module libexec/apache24/mod_authz_core.so
+#LoadModule authnz_fcgi_module libexec/apache24/mod_authnz_fcgi.so
+LoadModule access_compat_module libexec/apache24/mod_access_compat.so
+LoadModule auth_basic_module libexec/apache24/mod_auth_basic.so
+#LoadModule auth_form_module libexec/apache24/mod_auth_form.so
+#LoadModule auth_digest_module libexec/apache24/mod_auth_digest.so
+#LoadModule allowmethods_module libexec/apache24/mod_allowmethods.so
+#LoadModule file_cache_module libexec/apache24/mod_file_cache.so
+#LoadModule cache_module libexec/apache24/mod_cache.so
+#LoadModule cache_disk_module libexec/apache24/mod_cache_disk.so
+#LoadModule cache_socache_module libexec/apache24/mod_cache_socache.so
+#LoadModule socache_shmcb_module libexec/apache24/mod_socache_shmcb.so
+#LoadModule socache_dbm_module libexec/apache24/mod_socache_dbm.so
+#LoadModule socache_memcache_module libexec/apache24/mod_socache_memcache.so
+#LoadModule watchdog_module libexec/apache24/mod_watchdog.so
+#LoadModule macro_module libexec/apache24/mod_macro.so
+#LoadModule dbd_module libexec/apache24/mod_dbd.so
+#LoadModule dumpio_module libexec/apache24/mod_dumpio.so
+#LoadModule buffer_module libexec/apache24/mod_buffer.so
+#LoadModule data_module libexec/apache24/mod_data.so
+#LoadModule ratelimit_module libexec/apache24/mod_ratelimit.so
+LoadModule reqtimeout_module libexec/apache24/mod_reqtimeout.so
+#LoadModule ext_filter_module libexec/apache24/mod_ext_filter.so
+#LoadModule request_module libexec/apache24/mod_request.so
+#LoadModule include_module libexec/apache24/mod_include.so
+LoadModule filter_module libexec/apache24/mod_filter.so
+#LoadModule reflector_module libexec/apache24/mod_reflector.so
+#LoadModule substitute_module libexec/apache24/mod_substitute.so
+#LoadModule sed_module libexec/apache24/mod_sed.so
+#LoadModule charset_lite_module libexec/apache24/mod_charset_lite.so
+#LoadModule deflate_module libexec/apache24/mod_deflate.so
+#LoadModule xml2enc_module libexec/apache24/mod_xml2enc.so
+#LoadModule proxy_html_module libexec/apache24/mod_proxy_html.so
+LoadModule mime_module libexec/apache24/mod_mime.so
+LoadModule log_config_module libexec/apache24/mod_log_config.so
+#LoadModule log_debug_module libexec/apache24/mod_log_debug.so
+#LoadModule log_forensic_module libexec/apache24/mod_log_forensic.so
+#LoadModule logio_module libexec/apache24/mod_logio.so
+LoadModule env_module libexec/apache24/mod_env.so
+#LoadModule mime_magic_module libexec/apache24/mod_mime_magic.so
+#LoadModule cern_meta_module libexec/apache24/mod_cern_meta.so
+#LoadModule expires_module libexec/apache24/mod_expires.so
+LoadModule headers_module libexec/apache24/mod_headers.so
+#LoadModule usertrack_module libexec/apache24/mod_usertrack.so
+#LoadModule unique_id_module libexec/apache24/mod_unique_id.so
+LoadModule setenvif_module libexec/apache24/mod_setenvif.so
+LoadModule version_module libexec/apache24/mod_version.so
+#LoadModule remoteip_module libexec/apache24/mod_remoteip.so
+#LoadModule proxy_module libexec/apache24/mod_proxy.so
+#LoadModule proxy_connect_module libexec/apache24/mod_proxy_connect.so
+#LoadModule proxy_ftp_module libexec/apache24/mod_proxy_ftp.so
+#LoadModule proxy_http_module libexec/apache24/mod_proxy_http.so
+#LoadModule proxy_fcgi_module libexec/apache24/mod_proxy_fcgi.so
+#LoadModule proxy_scgi_module libexec/apache24/mod_proxy_scgi.so
+#LoadModule proxy_fdpass_module libexec/apache24/mod_proxy_fdpass.so
+#LoadModule proxy_wstunnel_module libexec/apache24/mod_proxy_wstunnel.so
+#LoadModule proxy_ajp_module libexec/apache24/mod_proxy_ajp.so
+#LoadModule proxy_balancer_module libexec/apache24/mod_proxy_balancer.so
+#LoadModule proxy_express_module libexec/apache24/mod_proxy_express.so
+#LoadModule proxy_hcheck_module libexec/apache24/mod_proxy_hcheck.so
+#LoadModule session_module libexec/apache24/mod_session.so
+#LoadModule session_cookie_module libexec/apache24/mod_session_cookie.so
+#LoadModule session_crypto_module libexec/apache24/mod_session_crypto.so
+#LoadModule session_dbd_module libexec/apache24/mod_session_dbd.so
+#LoadModule slotmem_shm_module libexec/apache24/mod_slotmem_shm.so
+#LoadModule slotmem_plain_module libexec/apache24/mod_slotmem_plain.so
+#LoadModule ssl_module libexec/apache24/mod_ssl.so
+#LoadModule dialup_module libexec/apache24/mod_dialup.so
+#LoadModule lbmethod_byrequests_module libexec/apache24/mod_lbmethod_byrequests.so
+#LoadModule lbmethod_bytraffic_module libexec/apache24/mod_lbmethod_bytraffic.so
+#LoadModule lbmethod_bybusyness_module libexec/apache24/mod_lbmethod_bybusyness.so
+#LoadModule lbmethod_heartbeat_module libexec/apache24/mod_lbmethod_heartbeat.so
+#LoadModule mpm_event_module libexec/apache24/mod_mpm_event.so
+LoadModule mpm_prefork_module libexec/apache24/mod_mpm_prefork.so
+#LoadModule mpm_worker_module libexec/apache24/mod_mpm_worker.so
+LoadModule unixd_module libexec/apache24/mod_unixd.so
+#LoadModule heartbeat_module libexec/apache24/mod_heartbeat.so
+#LoadModule heartmonitor_module libexec/apache24/mod_heartmonitor.so
+#LoadModule dav_module libexec/apache24/mod_dav.so
+LoadModule status_module libexec/apache24/mod_status.so
+LoadModule autoindex_module libexec/apache24/mod_autoindex.so
+#LoadModule asis_module libexec/apache24/mod_asis.so
+#LoadModule info_module libexec/apache24/mod_info.so
+#LoadModule suexec_module libexec/apache24/mod_suexec.so
+<IfModule !mpm_prefork_module>
+	#LoadModule cgid_module libexec/apache24/mod_cgid.so
+</IfModule>
+<IfModule mpm_prefork_module>
+	#LoadModule cgi_module libexec/apache24/mod_cgi.so
+</IfModule>
+#LoadModule dav_fs_module libexec/apache24/mod_dav_fs.so
+#LoadModule dav_lock_module libexec/apache24/mod_dav_lock.so
+#LoadModule vhost_alias_module libexec/apache24/mod_vhost_alias.so
+#LoadModule negotiation_module libexec/apache24/mod_negotiation.so
+LoadModule dir_module libexec/apache24/mod_dir.so
+#LoadModule imagemap_module libexec/apache24/mod_imagemap.so
+#LoadModule actions_module libexec/apache24/mod_actions.so
+#LoadModule speling_module libexec/apache24/mod_speling.so
+#LoadModule userdir_module libexec/apache24/mod_userdir.so
+LoadModule alias_module libexec/apache24/mod_alias.so
+#LoadModule rewrite_module libexec/apache24/mod_rewrite.so
+
+# Third party modules
+IncludeOptional etc/apache24/modules.d/[0-9][0-9][0-9]_*.conf
+ 
+<IfModule unixd_module>
+#
+# If you wish httpd to run as a different user or group, you must run
+# httpd as root initially and it will switch.  
+#
+# User/Group: The name (or #number) of the user/group to run httpd as.
+# It is usually good practice to create a dedicated user and group for
+# running httpd, as with most system services.
+#
+User www
+Group www
+
+</IfModule>
+
+# 'Main' server configuration
+#
+# The directives in this section set up the values used by the 'main'
+# server, which responds to any requests that aren't handled by a
+# <VirtualHost> definition.  These values also provide defaults for
+# any <VirtualHost> containers you may define later in the file.
+#
+# All of these directives may appear inside <VirtualHost> containers,
+# in which case these default settings will be overridden for the
+# virtual host being defined.
+#
+
+#
+# ServerAdmin: Your address, where problems with the server should be
+# e-mailed.  This address appears on some server-generated pages, such
+# as error documents.  e.g. admin@your-domain.com
+#
+ServerAdmin root@localhost
+
+#
+# ServerName gives the name and port that the server uses to identify itself.
+# This can often be determined automatically, but we recommend you specify
+# it explicitly to prevent problems during startup.
+#
+# If your host doesn't have a registered DNS name, enter its IP address here.
+#
+#ServerName www.example.com:80
+
+#
+# Deny access to the entirety of your server's filesystem. You must
+# explicitly permit access to web content directories in other 
+# <Directory> blocks below.
+#
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+#
+# Note that from this point forward you must specifically allow
+# particular features to be enabled - so if something's not working as
+# you might expect, make sure that you have specifically enabled it
+# below.
+#
+
+#
+# DocumentRoot: The directory out of which you will serve your
+# documents. By default, all requests are taken from this directory, but
+# symbolic links and aliases may be used to point to other locations.
+#
+DocumentRoot "/usr/local/www/apache24/data"
+<Directory "/usr/local/www/apache24/data">
+    #
+    # Possible values for the Options directive are "None", "All",
+    # or any combination of:
+    #   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
+    #
+    # Note that "MultiViews" must be named *explicitly* --- "Options All"
+    # doesn't give it to you.
+    #
+    # The Options directive is both complicated and important.  Please see
+    # http://httpd.apache.org/docs/2.4/mod/core.html#options
+    # for more information.
+    #
+    Options Indexes FollowSymLinks
+
+    #
+    # AllowOverride controls what directives may be placed in .htaccess files.
+    # It can be "All", "None", or any combination of the keywords:
+    #   AllowOverride FileInfo AuthConfig Limit
+    #
+    AllowOverride None
+
+    #
+    # Controls who can get stuff from this server.
+    #
+    Require all granted
+</Directory>
+
+#
+# DirectoryIndex: sets the file that Apache will serve if a directory
+# is requested.
+#
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being 
+# viewed by Web clients. 
+#
+<Files ".ht*">
+    Require all denied
+</Files>
+
+#
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog "/var/log/httpd-error.log"
+
+#
+# LogLevel: Control the number of messages logged to the error_log.
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+#
+LogLevel warn
+
+<IfModule log_config_module>
+    #
+    # The following directives define some format nicknames for use with
+    # a CustomLog directive (see below).
+    #
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+
+    #
+    # The location and format of the access logfile (Common Logfile Format).
+    # If you do not define any access logfiles within a <VirtualHost>
+    # container, they will be logged here.  Contrariwise, if you *do*
+    # define per-<VirtualHost> access logfiles, transactions will be
+    # logged therein and *not* in this file.
+    #
+    CustomLog "/var/log/httpd-access.log" common
+
+    #
+    # If you prefer a logfile with access, agent, and referer information
+    # (Combined Logfile Format) you can use the following directive.
+    #
+    #CustomLog "/var/log/httpd-access.log" combined
+</IfModule>
+
+<IfModule alias_module>
+    #
+    # Redirect: Allows you to tell clients about documents that used to 
+    # exist in your server's namespace, but do not anymore. The client 
+    # will make a new request for the document at its new location.
+    # Example:
+    # Redirect permanent /foo http://www.example.com/bar
+
+    #
+    # Alias: Maps web paths into filesystem paths and is used to
+    # access content that does not live under the DocumentRoot.
+    # Example:
+    # Alias /webpath /full/filesystem/path
+    #
+    # If you include a trailing / on /webpath then the server will
+    # require it to be present in the URL.  You will also likely
+    # need to provide a <Directory> section to allow access to
+    # the filesystem path.
+
+    #
+    # ScriptAlias: This controls which directories contain server scripts. 
+    # ScriptAliases are essentially the same as Aliases, except that
+    # documents in the target directory are treated as applications and
+    # run by the server when requested rather than as documents sent to the
+    # client.  The same rules about trailing "/" apply to ScriptAlias
+    # directives as to Alias.
+    #
+    ScriptAlias /cgi-bin/ "/usr/local/www/apache24/cgi-bin/"
+
+</IfModule>
+
+<IfModule cgid_module>
+    #
+    # ScriptSock: On threaded servers, designate the path to the UNIX
+    # socket used to communicate with the CGI daemon of mod_cgid.
+    #
+    #Scriptsock cgisock
+</IfModule>
+
+#
+# "/usr/local/www/apache24/cgi-bin" should be changed to whatever your ScriptAliased
+# CGI directory exists, if you have that configured.
+#
+<Directory "/usr/local/www/apache24/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule mime_module>
+    #
+    # TypesConfig points to the file containing the list of mappings from
+    # filename extension to MIME-type.
+    #
+    TypesConfig etc/apache24/mime.types
+
+    #
+    # AddType allows you to add to or override the MIME configuration
+    # file specified in TypesConfig for specific file types.
+    #
+    #AddType application/x-gzip .tgz
+    #
+    # AddEncoding allows you to have certain browsers uncompress
+    # information on the fly. Note: Not all browsers support this.
+    #
+    #AddEncoding x-compress .Z
+    #AddEncoding x-gzip .gz .tgz
+    #
+    # If the AddEncoding directives above are commented-out, then you
+    # probably should define those extensions to indicate media types:
+    #
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+
+    #
+    # AddHandler allows you to map certain file extensions to "handlers":
+    # actions unrelated to filetype. These can be either built into the server
+    # or added with the Action directive (see below)
+    #
+    # To use CGI scripts outside of ScriptAliased directories:
+    # (You will also need to add "ExecCGI" to the "Options" directive.)
+    #
+    #AddHandler cgi-script .cgi
+
+    # For type maps (negotiated resources):
+    #AddHandler type-map var
+
+    #
+    # Filters allow you to process content before it is sent to the client.
+    #
+    # To parse .shtml files for server-side includes (SSI):
+    # (You will also need to add "Includes" to the "Options" directive.)
+    #
+    #AddType text/html .shtml
+    #AddOutputFilter INCLUDES .shtml
+</IfModule>
+
+#
+# The mod_mime_magic module allows the server to use various hints from the
+# contents of the file itself to determine its type.  The MIMEMagicFile
+# directive tells the module where the hint definitions are located.
+#
+#MIMEMagicFile etc/apache24/magic
+
+#
+# Customizable error responses come in three flavors:
+# 1) plain text 2) local redirects 3) external redirects
+#
+# Some examples:
+#ErrorDocument 500 "The server made a boo boo."
+#ErrorDocument 404 /missing.html
+#ErrorDocument 404 "/cgi-bin/missing_handler.pl"
+#ErrorDocument 402 http://www.example.com/subscription_info.html
+#
+
+#
+# MaxRanges: Maximum number of Ranges in a request before
+# returning the entire resource, or one of the special
+# values 'default', 'none' or 'unlimited'.
+# Default setting is to accept 200 Ranges.
+#MaxRanges unlimited
+
+#
+# EnableMMAP and EnableSendfile: On systems that support it, 
+# memory-mapping or the sendfile syscall may be used to deliver
+# files.  This usually improves server performance, but must
+# be turned off when serving from networked-mounted 
+# filesystems or if support for these functions is otherwise
+# broken on your system.
+# Defaults: EnableMMAP On, EnableSendfile Off
+#
+#EnableMMAP off
+#EnableSendfile on
+
+# Supplemental configuration
+#
+# The configuration files in the etc/apache24/extra/ directory can be 
+# included to add extra features or to modify the default configuration of 
+# the server, or you may simply copy their contents here and change as 
+# necessary.
+
+# Server-pool management (MPM specific)
+#Include etc/apache24/extra/httpd-mpm.conf
+
+# Multi-language error messages
+#Include etc/apache24/extra/httpd-multilang-errordoc.conf
+
+# Fancy directory listings
+#Include etc/apache24/extra/httpd-autoindex.conf
+
+# Language settings
+#Include etc/apache24/extra/httpd-languages.conf
+
+# User home directories
+#Include etc/apache24/extra/httpd-userdir.conf
+
+# Real-time info on requests and configuration
+#Include etc/apache24/extra/httpd-info.conf
+
+# Virtual hosts
+#Include etc/apache24/extra/httpd-vhosts.conf
+
+# Local access to the Apache HTTP Server Manual
+#Include etc/apache24/extra/httpd-manual.conf
+
+# Distributed authoring and versioning (WebDAV)
+#Include etc/apache24/extra/httpd-dav.conf
+
+# Various default settings
+#Include etc/apache24/extra/httpd-default.conf
+
+# Configure mod_proxy_html to understand HTML4/XHTML1
+<IfModule proxy_html_module>
+Include etc/apache24/extra/proxy-html.conf
+</IfModule>
+
+# Secure (SSL/TLS) connections
+#Include etc/apache24/extra/httpd-ssl.conf
+#
+# Note: The following must must be present to support
+#       starting without SSL on platforms with no /dev/random equivalent
+#       but a statically compiled-in mod_ssl.
+#
+<IfModule ssl_module>
+SSLRandomSeed startup builtin
+SSLRandomSeed connect builtin
+</IfModule>
+
+Include etc/apache24/Includes/*.conf
+

--- a/apache/files/FreeBSD/envvars-2.4.jinja
+++ b/apache/files/FreeBSD/envvars-2.4.jinja
@@ -1,0 +1,53 @@
+# Managed by saltstack
+
+# envvars - default environment variables for apache2ctl
+
+# this won't be correct after changing uid
+unset HOME
+
+# for supporting multiple apache2 instances
+if [ "${APACHE_CONFDIR##/etc/apache2-}" != "${APACHE_CONFDIR}" ] ; then
+  SUFFIX="-${APACHE_CONFDIR##/etc/apache2-}"
+else
+  SUFFIX=
+fi
+
+# Since there is no sane way to get the parsed apache2 config in scripts, some
+# settings are defined via environment variables and then used in apache2ctl,
+# /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
+export APACHE_RUN_USER={{ salt['pillar.get']('apache:user', 'www-data') }}
+export APACHE_RUN_GROUP={{ salt['pillar.get']('apache:group', 'www-data') }}
+# temporary state file location. This might be changed to /run in Wheezy+1
+export APACHE_PID_FILE=/var/run/apache2/apache2$SUFFIX.pid
+export APACHE_RUN_DIR=/var/run/apache2$SUFFIX
+export APACHE_LOCK_DIR=/var/lock/apache2$SUFFIX
+# Only /var/log/apache2 is handled by /etc/logrotate.d/apache2.
+export APACHE_LOG_DIR=/var/log/apache2$SUFFIX
+
+## The locale used by some modules like mod_dav
+export LANG=C
+## Uncomment the following line to use the system default locale instead:
+#. /etc/default/locale
+
+export LANG
+
+## The command to get the status for 'apache2ctl status'.
+## Some packages providing 'www-browser' need '--dump' instead of '-dump'.
+#export APACHE_LYNX='www-browser -dump'
+
+## If you need a higher file descriptor limit, uncomment and adjust the
+## following line (default is 8192):
+#APACHE_ULIMIT_MAX_FILES='ulimit -n 65536'
+
+## If you would like to pass arguments to the web server, add them below
+## to the APACHE_ARGUMENTS environment.
+#export APACHE_ARGUMENTS=''
+
+## Enable the debug mode for maintainer scripts.
+## This will produce a verbose output on package installations of web server modules and web application
+## installations which interact with Apache
+#export APACHE2_MAINTSCRIPT_DEBUG=1
+
+{%- for envvar in salt['pillar.get']('apache:envvars', []) %}
+{{ envvar }}
+{%- endfor %}

--- a/apache/files/FreeBSD/envvars-2.4.jinja
+++ b/apache/files/FreeBSD/envvars-2.4.jinja
@@ -5,48 +5,14 @@
 # this won't be correct after changing uid
 unset HOME
 
-# for supporting multiple apache2 instances
-if [ "${APACHE_CONFDIR##/etc/apache2-}" != "${APACHE_CONFDIR}" ] ; then
-  SUFFIX="-${APACHE_CONFDIR##/etc/apache2-}"
-else
-  SUFFIX=
-fi
+APACHE_CONFDIR=/usr/local/etc/apache24
 
-# Since there is no sane way to get the parsed apache2 config in scripts, some
-# settings are defined via environment variables and then used in apache2ctl,
-# /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
-export APACHE_RUN_USER={{ salt['pillar.get']('apache:user', 'www-data') }}
-export APACHE_RUN_GROUP={{ salt['pillar.get']('apache:group', 'www-data') }}
-# temporary state file location. This might be changed to /run in Wheezy+1
-export APACHE_PID_FILE=/var/run/apache2/apache2$SUFFIX.pid
-export APACHE_RUN_DIR=/var/run/apache2$SUFFIX
-export APACHE_LOCK_DIR=/var/lock/apache2$SUFFIX
-# Only /var/log/apache2 is handled by /etc/logrotate.d/apache2.
-export APACHE_LOG_DIR=/var/log/apache2$SUFFIX
+export APACHE_RUN_USER={{ salt['pillar.get']('apache:user', 'www') }}
+export APACHE_RUN_GROUP={{ salt['pillar.get']('apache:group', 'www') }}
+export APACHE_RUN_DIR={{ salt['pillar.get']('apache:run_dir', '/var/run') }}
 
 ## The locale used by some modules like mod_dav
-export LANG=C
-## Uncomment the following line to use the system default locale instead:
-#. /etc/default/locale
-
-export LANG
-
-## The command to get the status for 'apache2ctl status'.
-## Some packages providing 'www-browser' need '--dump' instead of '-dump'.
-#export APACHE_LYNX='www-browser -dump'
-
-## If you need a higher file descriptor limit, uncomment and adjust the
-## following line (default is 8192):
-#APACHE_ULIMIT_MAX_FILES='ulimit -n 65536'
-
-## If you would like to pass arguments to the web server, add them below
-## to the APACHE_ARGUMENTS environment.
-#export APACHE_ARGUMENTS=''
-
-## Enable the debug mode for maintainer scripts.
-## This will produce a verbose output on package installations of web server modules and web application
-## installations which interact with Apache
-#export APACHE2_MAINTSCRIPT_DEBUG=1
+export LANG=en_US.UTF-8
 
 {%- for envvar in salt['pillar.get']('apache:envvars', []) %}
 {{ envvar }}

--- a/apache/files/FreeBSD/generic_module.conf.jinja
+++ b/apache/files/FreeBSD/generic_module.conf.jinja
@@ -1,0 +1,4 @@
+# Managed by saltstack
+
+LoadModule {{ module_name }}_module libexec/apache24/mod_{{ module_name }}.so
+

--- a/apache/files/FreeBSD/mod_cgi.conf.jinja
+++ b/apache/files/FreeBSD/mod_cgi.conf.jinja
@@ -1,0 +1,8 @@
+{% from "apache/map.jinja" import apache with context %}
+
+<IfModule !mpm_prefork_module>
+	LoadModule cgid_module libexec/{{ apache.service }}/mod_cgid.so
+</IfModule>
+<IfModule mpm_prefork_module>
+	LoadModule cgi_module libexec/{{ apache.service }}/mod_cgi.so
+</IfModule>

--- a/apache/files/FreeBSD/mod_perl.conf.jinja
+++ b/apache/files/FreeBSD/mod_perl.conf.jinja
@@ -1,0 +1,3 @@
+{% from "apache/map.jinja" import apache with context %}
+
+LoadModule perl_module libexec/{{ apache.service }}/mod_perl.so

--- a/apache/files/FreeBSD/mod_php5.conf.jinja
+++ b/apache/files/FreeBSD/mod_php5.conf.jinja
@@ -1,4 +1,6 @@
-LoadModule php5_module /usr/local/libexec/apache24/libphp5.so
+{% from "apache/map.jinja" import apache with context %}
+
+LoadModule php5_module /usr/local/libexec/{{ apache.service }}/libphp5.so
 
 DirectoryIndex index.html index.php
 

--- a/apache/files/FreeBSD/mod_php5.conf.jinja
+++ b/apache/files/FreeBSD/mod_php5.conf.jinja
@@ -1,0 +1,10 @@
+LoadModule php5_module /usr/local/libexec/apache24/libphp5.so
+
+DirectoryIndex index.html index.php
+
+<FilesMatch "\.php$">
+    SetHandler application/x-httpd-php
+</FilesMatch>
+<FilesMatch "\.phps$">
+    SetHandler application/x-httpd-php-source
+</FilesMatch>

--- a/apache/files/FreeBSD/mod_proxy.conf.jinja
+++ b/apache/files/FreeBSD/mod_proxy.conf.jinja
@@ -1,0 +1,3 @@
+{% from "apache/map.jinja" import apache with context %}
+
+LoadModule proxy_module libexec/{{ apache.service }}/mod_proxy.so

--- a/apache/files/FreeBSD/mod_proxy_http.conf.jinja
+++ b/apache/files/FreeBSD/mod_proxy_http.conf.jinja
@@ -1,0 +1,3 @@
+{% from "apache/map.jinja" import apache with context %}
+
+LoadModule proxy_http_module libexec/{{ apache.service }}/mod_proxy_http.so

--- a/apache/files/FreeBSD/mod_rewrite.conf.jinja
+++ b/apache/files/FreeBSD/mod_rewrite.conf.jinja
@@ -1,0 +1,3 @@
+{% from "apache/map.jinja" import apache with context %}
+
+LoadModule rewrite_module libexec/{{ apache.service }}/mod_rewrite.so

--- a/apache/files/FreeBSD/mod_ssl.conf.jinja
+++ b/apache/files/FreeBSD/mod_ssl.conf.jinja
@@ -1,0 +1,214 @@
+# Managed by saltstack
+
+LoadModule ssl_module libexec/apache24/mod_ssl.so
+
+<IfModule mod_ssl.c>
+#
+# Pseudo Random Number Generator (PRNG):
+# Configure one or more sources to seed the PRNG of the SSL library.
+# The seed data should be of good random quality.
+# WARNING! On some platforms /dev/random blocks if not enough entropy
+# is available. This means you then cannot use the /dev/random device
+# because it would lead to very long connection times (as long as
+# it requires to make more entropy available). But usually those
+# platforms additionally provide a /dev/urandom device which doesn't
+# block. So, if available, use this one instead. Read the mod_ssl User
+# Manual for more details.
+#
+SSLRandomSeed startup builtin
+SSLRandomSeed startup file:/dev/urandom 512
+SSLRandomSeed connect builtin
+SSLRandomSeed connect file:/dev/urandom 512
+
+##
+##  SSL Global Context
+##
+##  All SSL configuration in this context applies both to
+##  the main server and all SSL-enabled virtual hosts.
+##
+
+#
+#   Some MIME-types for downloading Certificates and CRLs
+#
+AddType application/x-x509-ca-cert .crt
+AddType application/x-pkcs7-crl    .crl
+
+#   Pass Phrase Dialog:
+#   Configure the pass phrase gathering process.
+#   The filtering dialog program (`builtin' is a internal
+#   terminal dialog) has to provide the pass phrase on stdout.
+SSLPassPhraseDialog  builtin
+
+#   Inter-Process Session Cache:
+#   Configure the SSL Session Cache: First the mechanism 
+#   to use and second the expiring timeout (in seconds).
+#SSLSessionCache         dbm:${APACHE_RUN_DIR}/ssl_scache
+SSLSessionCache        shmcb:${APACHE_RUN_DIR}/ssl_scache(512000)
+SSLSessionCacheTimeout  300
+
+#   Semaphore:
+#   Configure the path to the mutual exclusion semaphore the
+#   SSL engine uses internally for inter-process synchronization. 
+<IfVersion < 2.4>
+SSLMutex  file:${APACHE_RUN_DIR}/ssl_mutex
+</IfVersion>
+
+#   SSL Cipher Suite:
+#   List the ciphers that the client is permitted to negotiate.
+#   See the mod_ssl documentation for a complete list.
+#   enable only secure ciphers:
+#SSLCipherSuite HIGH:MEDIUM:!ADH
+SSLCipherSuite EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA
+
+# Mitigate the CRIME attack
+#SSLCompression off
+
+#   Use this instead if you want to allow cipher upgrades via SGC facility.
+#   In this case you also have to use something like 
+#        SSLRequire %{SSL_CIPHER_USEKEYSIZE} >= 128
+#   see http://httpd.apache.org/docs/2.2/ssl/ssl_howto.html.en#upgradeenc
+#SSLCipherSuite ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP:+eNULL
+
+# enable only secure protocols: SSLv3 and TLSv1, but not SSLv2
+SSLProtocol all -SSLv2 -SSLv3
+
+SSLHonorCipherOrder On
+
+# (bettercrypto.org)
+# Add six earth month HSTS header for all users...
+Header add Strict-Transport-Security "max-age=15768000"
+# If you want to protect all subdomains, use the following header
+# ALL subdomains HAVE TO support HTTPS if you use this!
+# Strict-Transport-Security: max-age=15768000 ; includeSubDomains
+
+#   SSL Engine Switch:
+#   Enable/Disable SSL for this virtual host.
+SSLEngine on
+SSLOptions +StrictRequire
+
+#   A self-signed (snakeoil) certificate can be created by installing
+#   the ssl-cert package. See
+#   /usr/share/doc/apache2.2-common/README.Debian.gz for more info.
+#   If both key and certificate are stored in the same file, only the
+#   SSLCertificateFile directive is needed.
+SSLCertificateFile    /usr/local/etc/apache24/ssl/apache2-cert.pem
+SSLCertificateKeyFile /usr/local/etc/apache24/ssl/apache2-key.pem
+
+#   Server Certificate Chain:
+#   Point SSLCertificateChainFile at a file containing the
+#   concatenation of PEM encoded CA certificates which form the
+#   certificate chain for the server certificate. Alternatively
+#   the referenced file can be the same as SSLCertificateFile
+#   when the CA certificates are directly appended to the server
+#   certificate for convinience.
+#SSLCertificateChainFile /usr/local/etc/apache24/ssl.crt/server-ca.crt
+
+#   Certificate Authority (CA):
+#   Set the CA certificate verification path where to find CA
+#   certificates for client authentication or alternatively one
+#   huge file containing all of them (file must be PEM encoded)
+#   Note: Inside SSLCACertificatePath you need hash symlinks
+#         to point to the certificate files. Use the provided
+#         Makefile to update the hash symlinks after changes.
+#SSLCACertificatePath /etc/ssl/certs/
+#SSLCACertificateFile /usr/local/etc/apache24/ssl.crt/ca-bundle.crt
+
+#   Certificate Revocation Lists (CRL):
+#   Set the CA revocation path where to find CA CRLs for client
+#   authentication or alternatively one huge file containing all
+#   of them (file must be PEM encoded)
+#   Note: Inside SSLCARevocationPath you need hash symlinks
+#         to point to the certificate files. Use the provided
+#         Makefile to update the hash symlinks after changes.
+#SSLCARevocationPath /usr/local/etc/apache24/ssl.crl/
+#SSLCARevocationFile /usr/local/etc/apache24/ssl.crl/ca-bundle.crl
+
+#   Client Authentication (Type):
+#   Client certificate verification type and depth.  Types are
+#   none, optional, require and optional_no_ca.  Depth is a
+#   number which specifies how deeply to verify the certificate
+#   issuer chain before deciding the certificate is not valid.
+#SSLVerifyClient require
+#SSLVerifyDepth  10
+
+#   Access Control:
+#   With SSLRequire you can do per-directory access control based
+#   on arbitrary complex boolean expressions containing server
+#   variable checks and other lookup directives.  The syntax is a
+#   mixture between C and Perl.  See the mod_ssl documentation
+#   for more details.
+#<Location />
+#SSLRequire (    %{SSL_CIPHER} !~ m/^(EXP|NULL)/ \
+#            and %{SSL_CLIENT_S_DN_O} eq "Snake Oil, Ltd." \
+#            and %{SSL_CLIENT_S_DN_OU} in {"Staff", "CA", "Dev"} \
+#            and %{TIME_WDAY} >= 1 and %{TIME_WDAY} <= 5 \
+#            and %{TIME_HOUR} >= 8 and %{TIME_HOUR} <= 20       ) \
+#           or %{REMOTE_ADDR} =~ m/^192\.76\.162\.[0-9]+$/
+#</Location>
+
+#   SSL Engine Options:
+#   Set various options for the SSL engine.
+#   o FakeBasicAuth:
+#     Translate the client X.509 into a Basic Authorisation.  This means that
+#     the standard Auth/DBMAuth methods can be used for access control.  The
+#     user name is the `one line' version of the client's X.509 certificate.
+#     Note that no password is obtained from the user. Every entry in the user
+#     file needs this password: `xxj31ZMTZzkVA'.
+#   o ExportCertData:
+#     This exports two additional environment variables: SSL_CLIENT_CERT and
+#     SSL_SERVER_CERT. These contain the PEM-encoded certificates of the
+#     server (always existing) and the client (only existing when client
+#     authentication is used). This can be used to import the certificates
+#     into CGI scripts.
+#   o StdEnvVars:
+#     This exports the standard SSL/TLS related `SSL_*' environment variables.
+#     Per default this exportation is switched off for performance reasons,
+#     because the extraction step is an expensive operation and is usually
+#     useless for serving static content. So one usually enables the
+#     exportation for CGI and SSI requests only.
+#   o StrictRequire:
+#     This denies access when "SSLRequireSSL" or "SSLRequire" applied even
+#     under a "Satisfy any" situation, i.e. when it applies access is denied
+#     and no other module can change it.
+#   o OptRenegotiate:
+#     This enables optimized SSL connection renegotiation handling when SSL
+#     directives are used in per-directory context.
+#SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
+<FilesMatch "\.(cgi|shtml|phtml|php)$">
+	SSLOptions +StdEnvVars
+</FilesMatch>
+<Directory /usr/lib/cgi-bin>
+	SSLOptions +StdEnvVars
+</Directory>
+
+#   SSL Protocol Adjustments:
+#   The safe and default but still SSL/TLS standard compliant shutdown
+#   approach is that mod_ssl sends the close notify alert but doesn't wait for
+#   the close notify alert from client. When you need a different shutdown
+#   approach you can use one of the following variables:
+#   o ssl-unclean-shutdown:
+#     This forces an unclean shutdown when the connection is closed, i.e. no
+#     SSL close notify alert is send or allowed to received.  This violates
+#     the SSL/TLS standard but is needed for some brain-dead browsers. Use
+#     this when you receive I/O errors because of the standard approach where
+#     mod_ssl sends the close notify alert.
+#   o ssl-accurate-shutdown:
+#     This forces an accurate shutdown when the connection is closed, i.e. a
+#     SSL close notify alert is send and mod_ssl waits for the close notify
+#     alert of the client. This is 100% SSL/TLS standard compliant, but in
+#     practice often causes hanging connections with brain-dead browsers. Use
+#     this only for browsers where you know that their SSL implementation
+#     works correctly.
+#   Notice: Most problems of broken clients are also related to the HTTP
+#   keep-alive facility, so you usually additionally want to disable
+#   keep-alive for those clients, too. Use variable "nokeepalive" for this.
+#   Similarly, one has to force some clients to use HTTP/1.0 to workaround
+#   their broken HTTP/1.1 implementation. Use variables "downgrade-1.0" and
+#   "force-response-1.0" for this.
+BrowserMatch "MSIE [2-6]" \
+	nokeepalive ssl-unclean-shutdown \
+	downgrade-1.0 force-response-1.0
+# MSIE 7 and newer should be able to use keepalive
+BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
+
+</IfModule>

--- a/apache/files/FreeBSD/mod_ssl.conf.jinja
+++ b/apache/files/FreeBSD/mod_ssl.conf.jinja
@@ -91,8 +91,8 @@ SSLOptions +StrictRequire
 #   /usr/share/doc/apache2.2-common/README.Debian.gz for more info.
 #   If both key and certificate are stored in the same file, only the
 #   SSLCertificateFile directive is needed.
-SSLCertificateFile    /usr/local/etc/apache24/ssl/apache2-cert.pem
-SSLCertificateKeyFile /usr/local/etc/apache24/ssl/apache2-key.pem
+SSLCertificateFile    {{ salt['pillar.get']('apache:ssl:default_cert', '/usr/local/etc/apache24/server.crt') }}
+SSLCertificateKeyFile {{ salt['pillar.get']('apache:ssl:default_key', '/usr/local/etc/apache24/server.key') }}
 
 #   Server Certificate Chain:
 #   Point SSLCertificateChainFile at a file containing the

--- a/apache/files/FreeBSD/mod_suexec.conf.jinja
+++ b/apache/files/FreeBSD/mod_suexec.conf.jinja
@@ -1,0 +1,3 @@
+{% from "apache/map.jinja" import apache with context %}
+
+LoadModule suexec_module libexec/{{ apache.service }}/mod_suexec.so

--- a/apache/files/FreeBSD/ports-2.4.conf.jinja
+++ b/apache/files/FreeBSD/ports-2.4.conf.jinja
@@ -1,0 +1,47 @@
+{%- from "apache/map.jinja" import apache with context -%}
+
+# Managed by saltstack
+
+{% if salt['pillar.get']('apache:sites') is mapping %}
+    {%- set listen_directives = [] %}
+    {%- for id, site in salt['pillar.get']('apache:sites').items() %}
+        {%- set interfaces = site.get('interface', '*').split() %}
+        {%- set port = site.get('port', 80) %}
+        {%- for interface in interfaces %}
+            {%- if not site.get('exclude_listen_directive', False) %}
+                {%- set listen_directive = interface ~ ':' ~ port %}
+                {%- if listen_directive not in listen_directives %}
+                    {%- do listen_directives.append(listen_directive) %}
+                {%- endif %}
+            {%- endif %}
+        {%- endfor %}
+    {%- endfor %}
+    {%- for listen in listen_directives %}
+Listen  {{ listen }}
+    {%- endfor %}
+{%- else %}
+Listen 80
+
+<IfModule mod_ssl.c>
+    Listen 443
+</IfModule>
+
+<IfModule mod_gnutls.c>
+    Listen 443
+</IfModule>
+{%- endif %}
+
+{%- if salt['pillar.get']('apache:name_virtual_hosts') is iterable %}
+    {%- set name_virtual_host_directives = [] %}
+
+    {%- for name_virtual_host in salt['pillar.get']('apache:name_virtual_hosts') %}
+        {%- set interface = name_virtual_host.get('interface', '*') %}
+        {%- set port = name_virtual_host.get('port', 80) %}
+        {%- set name_virtual_host_directive = interface ~ ':' ~ port %}
+        {%- do name_virtual_host_directives.append(name_virtual_host_directive) %}
+    {%- endfor %}
+
+    {%- for name_virtual_host in name_virtual_host_directives %}
+NameVirtualHost  {{ name_virtual_host }}
+    {%- endfor %}
+{%- endif -%}

--- a/apache/files/FreeBSD/security.conf.jinja
+++ b/apache/files/FreeBSD/security.conf.jinja
@@ -1,0 +1,3 @@
+{% for option, value in salt['pillar.get']('apache:security', {}).items() -%}
+{{ option }} {{ value }}
+{% endfor %}

--- a/apache/manage_security.sls
+++ b/apache/manage_security.sls
@@ -1,9 +1,9 @@
-{% if grains['os_family']=="Debian" %}
-
 {% from "apache/map.jinja" import apache with context %}
 
 include:
   - apache
+
+{% if grains['os_family']=="Debian" %}
 
 {% if salt['file.file_exists' ]('/etc/apache2/conf-available/security.conf') %}
 apache_security-block:
@@ -30,4 +30,14 @@ apache_manage-security-{{ option }}:
 
 {% endif %}
 
+{% elif grains['os_family']=="FreeBSD" %}
+{{ apache.confdir }}/security.conf:
+  file.managed:
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/security.conf.jinja
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
 {% endif %}

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -28,6 +28,7 @@
 
         'mod_wsgi': 'libapache2-mod-wsgi',
         'mod_php5': 'libapache2-mod-php5',
+        'mod_perl2': 'libapache2-mod-perl2',
         'mod_fcgid': 'libapache2-mod-fcgid',
         'mod_pagespeed_source': 'https://dl-ssl.google.com/dl/linux/direct/mod-pagespeed-stable_current_amd64.deb',
 
@@ -86,6 +87,7 @@
         'portsfile': '/usr/local/etc/apache22/ports.conf',
 
         'mod_php5': 'mod_php56',
+        'mod_perl2': 'ap22-mod_perl2',
         'mod_wsgi': 'ap22-mod_wsgi3',
 
         'vhostdir': '/usr/local/etc/apache22/Includes',

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -89,7 +89,7 @@
         'mod_wsgi': 'ap22-mod_wsgi3',
 
         'vhostdir': '/usr/local/etc/apache22/Includes',
-        'confdir': '/usr/local/etc/apache22/Includes',
+        'confdir': '/usr/local/etc/apache22/extra',
         'modulesdir': '/usr/local/etc/apache22/modules.d',
         'global_document_root': '/usr/local/www/apache22/data',
 

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -89,6 +89,7 @@
 
         'vhostdir': '/usr/local/etc/apache22/Includes',
         'confdir': '/usr/local/etc/apache22/Includes',
+        'modulesdir': '/usr/local/etc/apache22/modules.d',
         'confext': '',
         'default_site': 'default',
         'default_site_ssl': 'default-ssl',

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -85,6 +85,7 @@
         'configfile': '/usr/local/etc/apache22/httpd.conf',
         'portsfile': '/usr/local/etc/apache22/ports.conf',
 
+        'mod_php5': 'mod_php56',
         'mod_wsgi': 'ap22-mod_wsgi3',
 
         'vhostdir': '/usr/local/etc/apache22/Includes',

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -83,6 +83,7 @@
         'server': 'apache22',
         'service': 'apache22',
         'configfile': '/usr/local/etc/apache22/httpd.conf',
+        'portsfile': '/usr/local/etc/apache22/ports.conf',
 
         'mod_wsgi': 'ap22-mod_wsgi3',
 

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -90,6 +90,8 @@
         'vhostdir': '/usr/local/etc/apache22/Includes',
         'confdir': '/usr/local/etc/apache22/Includes',
         'modulesdir': '/usr/local/etc/apache22/modules.d',
+        'global_document_root': '/usr/local/www/apache22/data',
+
         'confext': '',
         'default_site': 'default',
         'default_site_ssl': 'default-ssl',

--- a/apache/mod_cgi.sls
+++ b/apache/mod_cgi.sls
@@ -1,0 +1,18 @@
+{% from "apache/map.jinja" import apache with context %}
+
+include:
+  - apache
+
+{% if grains['os_family']=="FreeBSD" %}
+
+{{ apache.modulesdir }}/040_mod_cgi.conf:
+  file.managed:
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/mod_cgi.conf.jinja
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+
+{% endif %}

--- a/apache/mod_perl2.sls
+++ b/apache/mod_perl2.sls
@@ -1,0 +1,35 @@
+{% from "apache/map.jinja" import apache with context %}
+
+include:
+  - apache
+
+mod-perl2:
+  pkg.installed:
+    - name: {{ apache.mod_perl2 }}
+    - order: 180
+    - require:
+      - pkg: apache
+
+{% if grains['os_family']=="Debian" %}
+a2enmod perl2:
+  cmd.run:
+    - unless: ls /etc/apache2/mods-enabled/perl2.load
+    - order: 225
+    - require:
+      - pkg: mod-perl2
+    - watch_in:
+      - module: apache-restart
+
+{% elif grains['os_family']=="FreeBSD" %}
+
+{{ apache.modulesdir }}/260_mod_perl.conf:
+  file.managed:
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/mod_perl.conf.jinja
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+
+{% endif %}

--- a/apache/mod_php5.sls
+++ b/apache/mod_php5.sls
@@ -32,4 +32,16 @@ a2enmod php5:
       - pkg: mod-php5
 {% endif %}
 
+{% elif grains['os_family']=="FreeBSD" %}
+
+{{ apache.modulesdir }}/050_mod_php5.conf:
+  file.managed:
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/mod_php5.conf.jinja
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+
 {% endif %}

--- a/apache/mod_proxy.sls
+++ b/apache/mod_proxy.sls
@@ -1,13 +1,25 @@
-{% if grains['os_family']=="Debian" %}
+{% from "apache/map.jinja" import apache with context %}
 
 include:
   - apache
 
+{% if grains['os_family']=="Debian" %}
 a2enmod mod_proxy:
   cmd.run:
     - name: a2enmod proxy
     - unless: ls /etc/apache2/mods-enabled/proxy.load
     - order: 225
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+
+{% elif grains['os_family']=="FreeBSD" %}
+{{ apache.modulesdir }}/040_mod_proxy.conf:
+  file.managed:
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/mod_proxy.conf.jinja
+    - mode: 644
+    - template: jinja
     - require:
       - pkg: apache
     - watch_in:

--- a/apache/mod_proxy_http.sls
+++ b/apache/mod_proxy_http.sls
@@ -1,3 +1,5 @@
+{% from "apache/map.jinja" import apache with context %}
+
 {% if grains['os_family']=="Debian" %}
 
 include:
@@ -11,6 +13,17 @@ a2enmod proxy_http:
     - require:
       - pkg: apache
       - cmd: a2enmod proxy
+    - watch_in:
+      - module: apache-restart
+
+{% elif grains['os_family']=="FreeBSD" %}
+{{ apache.modulesdir }}/040_mod_proxy_http.conf:
+  file.managed:
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/mod_proxy_http.conf.jinja
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: apache
     - watch_in:
       - module: apache-restart
 

--- a/apache/mod_rewrite.sls
+++ b/apache/mod_rewrite.sls
@@ -1,12 +1,25 @@
-{% if grains['os_family']=="Debian" %}
+{% from "apache/map.jinja" import apache with context %}
 
 include:
   - apache
 
+{% if grains['os_family']=="Debian" %}
 a2enmod rewrite:
   cmd.run:
     - unless: ls /etc/apache2/mods-enabled/rewrite.load
     - order: 225
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+
+{% elif grains['os_family']=="FreeBSD" %}
+
+{{ apache.modulesdir }}/040_mod_rewrite.conf:
+  file.managed:
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/mod_rewrite.conf.jinja
+    - mode: 644
+    - template: jinja
     - require:
       - pkg: apache
     - watch_in:

--- a/apache/mod_socache_shmcb.sls
+++ b/apache/mod_socache_shmcb.sls
@@ -1,0 +1,20 @@
+{% from "apache/map.jinja" import apache with context %}
+
+{% if grains['os_family']=="FreeBSD" %}
+
+include:
+  - apache
+
+{{ apache.modulesdir }}/009_mod_socache_shmcb.conf:
+  file.managed:
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/generic_module.conf.jinja
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+    - context:
+      module_name: socache_shmcb
+
+{% endif %}

--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -1,3 +1,5 @@
+{% from "apache/map.jinja" import apache with context %}
+
 {% if grains['os_family']=="Debian" %}
 
 include:
@@ -17,6 +19,22 @@ a2enmod mod_ssl:
 
 mod_ssl:
   pkg.installed:
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+
+{% elif grains['os_family']=="FreeBSD" %}
+
+include:
+  - apache
+  - apache.mod_socache_shmcb
+
+{{ apache.modulesdir }}/010_mod_ssl.conf:
+  file.managed:
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/mod_ssl.conf.jinja
+    - mode: 644
+    - template: jinja
     - require:
       - pkg: apache
     - watch_in:

--- a/apache/mod_suexec.sls
+++ b/apache/mod_suexec.sls
@@ -1,0 +1,18 @@
+{% from "apache/map.jinja" import apache with context %}
+
+include:
+  - apache
+
+{% if grains['os_family']=="FreeBSD" %}
+
+{{ apache.modulesdir }}/040_mod_suexec.conf:
+  file.managed:
+    - source: salt://apache/files/{{ salt['grains.get']('os_family') }}/mod_suexec.conf.jinja
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+
+{% endif %}


### PR DESCRIPTION
**Summary of Changes**
- Added basic FreeBSD support
- global DocumentRoot
- envvars
- mod_perl2
- mod_proxy
- mod_php5
- mod_ssl
- mod_suexec
- mod_rewrite
- apache.global for Debian and FreeBSD

**Testing**
- tested on OS
