### PR TITLE
Include the mod_* states in apache.modules for Debian hosts

### DIFF
--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -2,17 +2,9 @@
 
 include:
   - apache
-
-{% for module in salt['pillar.get']('apache:modules:enabled', []) %}
-a2enmod {{ module }}:
-  cmd.run:
-    - unless: ls /etc/apache2/mods-enabled/{{ module }}.load
-    - order: 225
-    - require:
-      - pkg: apache
-    - watch_in:
-      - module: apache-restart
-{% endfor %}
+{%- for module in salt['pillar.get']('apache:modules:enabled', []) %}
+  - apache.mod_{{ module }}
+{%- endfor %}
 
 {% for module in salt['pillar.get']('apache:modules:disabled', []) %}
 a2dismod -f {{ module }}:


### PR DESCRIPTION
The formula provides an option to enable Apache modules using pillar data, but this does not install packages dependencies as well. This can result is states failing to be applied because packages are missing.

By including the mod_\* states in the apache.modules the package dependencies should be handled correctly and it improves DRY of a2enmod cmds.

This is only applied for Debian hosts because the individual mod_\* states don't seem to support enabling modules for RedHat hosts.

Tested on Debian
