### PR TITLE
[+] debian apache2 needs to have conf enabled when making this change

### DIFF
--- a/apache/mod_remoteip.sls
+++ b/apache/mod_remoteip.sls
@@ -12,6 +12,15 @@ a2enmod remoteip:
     - watch_in:
       - module: apache-restart
 
+a2enconf remoteip:
+  cmd.run:
+    - unless: ls /etc/apache2/mods-enabled/remoteip.load
+    - order: 255
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-reload
+
 /etc/apache2/conf-available/remoteip.conf:
   file.managed:
     - template: jinja
@@ -21,5 +30,4 @@ a2enmod remoteip:
       - pkg: apache
     - watch_in:
       - service: apache
-
 {% endif %}


### PR DESCRIPTION
**Summary of Changes**
 * Issue summary 
 - If mod_remoteip is being ran for the first time the a2enconf remoteip commands need to ran as well.
**Testing**
 - Tested on OS 
