### PR TITLE
fixes in SUSE support

### DIFF
--- a/apache/config.sls
+++ b/apache/config.sls
@@ -57,7 +57,7 @@ include:
 {% endif %}
 
 {% if grains['os_family']=="Suse" %}
-/etc/apache2/sysconfig.d/global.conf:
+/etc/apache2/global.conf:
   file.managed:
     - template: jinja
     - source:

--- a/apache/files/Suse/apache-2.4.config.jinja
+++ b/apache/files/Suse/apache-2.4.config.jinja
@@ -3,7 +3,7 @@
 #
 # This is the main Apache server configuration file.  It contains the
 # configuration directives that give the server its instructions.
-# See <URL:http:///httpd.apache.org/docs/2.4/> for detailed information about
+# See <URL:http://httpd.apache.org/docs/2.4/> for detailed information about
 # the directives.
 
 # Based upon the default apache configuration file that ships with apache,
@@ -193,7 +193,7 @@ Include /etc/apache2/sysconfig.d/include.conf
 # IP addresses. This is indicated by the asterisks in the directives below.
 #
 # Please see the documentation at
-# <URL:http:///httpd.apache.org/docs/2.4/vhosts/>
+# <URL:http://httpd.apache.org/docs/2.4/vhosts/>
 # for further details before you try to setup virtual hosts.
 #
 # You may use the command line option '-S' to verify your virtual host

--- a/apache/files/Suse/apache-2.4.config.jinja
+++ b/apache/files/Suse/apache-2.4.config.jinja
@@ -27,7 +27,7 @@
 #  |-- sysconfig.d/loadmodule.conf . . . . .  [*] load these modules
 #  |-- listen.conf . . . . . . . . . . . . .  IP adresses / ports to listen on
 #  |-- mod_log_config.conf . . . . . . . . .  define logging formats
-#  |-- sysconfig.d/global.conf . . . . . . .  [*] server-wide general settings
+#  |-- global.conf . . . . . . . . . . . . .  server-wide general settings
 #  |-- mod_status.conf . . . . . . . . . . .  restrict access to mod_status (server monitoring)
 #  |-- mod_info.conf . . . . . . . . . . . .  restrict access to mod_info
 #  |-- mod_usertrack.conf  . . . . . . . . .  defaults for cookie-based user tracking
@@ -121,8 +121,8 @@ Include /etc/apache2/listen.conf
 # predefined logging formats
 Include /etc/apache2/mod_log_config.conf
 
-# generated from global settings in /etc/sysconfig/apache2
-Include /etc/apache2/sysconfig.d/global.conf
+# global settings managed by salt
+Include /etc/apache2/global.conf
 
 # optional mod_status, mod_info
 Include /etc/apache2/mod_status.conf

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -72,7 +72,7 @@
         'mod_fcgid': 'apache2-mod_fcgid',
 
         'vhostdir': '/etc/apache2/vhosts.d',
-        'confdir': '/etc/httpd/conf.d',
+        'confdir': '/etc/apache2/conf.d',
         'confext': '.conf',
         'default_site': 'vhost.template',
         'default_site_ssl': 'vhost-ssl.template',


### PR DESCRIPTION
The important change is to use `/etc/apache2/global.conf`
because `/etc/apache2/sysconfig.d/global.conf` is over-written from sysconfig values when the apache service is restarted. That causes salt to never reach a cleanly applied state.

+fixed some typos

**Testing**
 - Tested on SUSE Linux Enterprise Server 12 SP2 using salt-ssh-2016.11.3