### PR TITLE
drop %O from default LogFormat

### DIFF
--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -17,7 +17,7 @@
 
     'LogLevel': site.get('LogLevel', 'warn'),
     'ErrorLog': site.get('ErrorLog', '{0}/{1}-error.log'.format(map.logdir, sitename)),
-    'LogFormat': site.get('LogFormat', '"%h %l %u %t \\\"%r\\\" %>s %O"'),
+    'LogFormat': site.get('LogFormat', '"%h %l %u %t \\\"%r\\\" %>s"'),
     'CustomLog': site.get('CustomLog', '{0}/{1}-access.log'.format(map.logdir, sitename)),
 
     'DocumentRoot': site.get('DocumentRoot', '{0}/{1}'.format(map.wwwdir, sitename)),


### PR DESCRIPTION
**Summary of Changes**
 * the default template would fail on a default apache config/setup
 * syslog had `Unrecognized LogFormat directive %O`
   - because LogFormat %O requires mod_logio to be enabled


**Testing**
 - Tested on SUSE Linux Enterprise Server 12 SP2