### PR TITLE
Fix: wsgi.conf file not found on CentOS 7

### DIFF
--- a/apache/mod_wsgi.sls
+++ b/apache/mod_wsgi.sls
@@ -9,7 +9,7 @@ mod_wsgi:
     - require:
       - pkg: apache
 
-{% if grains.get('os_family') == 'RedHat' %}
+{% if grains.get('os_family') == 'RedHat' and salt['file.file_exists']('/etc/httpd/conf.d/wsgi.conf') %}
 /etc/httpd/conf.d/wsgi.conf:
   file.uncomment:
     - regex: LoadModule


### PR DESCRIPTION
Fix an issue when `/etc/httpd/conf.d/wsgi.conf` is not present during mod_wsgi installation on CentOS 7.
Resolves next issue: #163 