### PR TITLE
Add default user/group attributes as required by some states

### DIFF
--- a/apache/files/Debian/envvars-2.2.jinja
+++ b/apache/files/Debian/envvars-2.2.jinja
@@ -1,3 +1,4 @@
+{%- from "apache/map.jinja" import apache with context -%}
 # Managed by saltstack
 
 # envvars - default environment variables for apache2ctl
@@ -15,8 +16,8 @@ fi
 # Since there is no sane way to get the parsed apache2 config in scripts, some
 # settings are defined via environment variables and then used in apache2ctl,
 # /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
-export APACHE_RUN_USER={{ salt['pillar.get']('apache:user', 'www-data') }}
-export APACHE_RUN_GROUP={{ salt['pillar.get']('apache:group', 'www-data') }}
+export APACHE_RUN_USER={{ apache.user }}
+export APACHE_RUN_GROUP={{ apache.group }}
 export APACHE_PID_FILE=/var/run/apache2$SUFFIX.pid
 export APACHE_RUN_DIR=/var/run/apache2$SUFFIX
 export APACHE_LOCK_DIR=/var/lock/apache2$SUFFIX

--- a/apache/files/Debian/envvars-2.4.jinja
+++ b/apache/files/Debian/envvars-2.4.jinja
@@ -1,3 +1,4 @@
+{%- from "apache/map.jinja" import apache with context -%}
 # Managed by saltstack
 
 # envvars - default environment variables for apache2ctl
@@ -15,8 +16,8 @@ fi
 # Since there is no sane way to get the parsed apache2 config in scripts, some
 # settings are defined via environment variables and then used in apache2ctl,
 # /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
-export APACHE_RUN_USER={{ salt['pillar.get']('apache:user', 'www-data') }}
-export APACHE_RUN_GROUP={{ salt['pillar.get']('apache:group', 'www-data') }}
+export APACHE_RUN_USER={{ apache.user }}
+export APACHE_RUN_GROUP={{ apache.group }}
 # temporary state file location. This might be changed to /run in Wheezy+1
 export APACHE_PID_FILE=/var/run/apache2/apache2$SUFFIX.pid
 export APACHE_RUN_DIR=/var/run/apache2$SUFFIX

--- a/apache/files/FreeBSD/envvars-2.4.jinja
+++ b/apache/files/FreeBSD/envvars-2.4.jinja
@@ -1,3 +1,4 @@
+{%- from "apache/map.jinja" import apache with context -%}
 # Managed by saltstack
 
 # envvars - default environment variables for apache2ctl
@@ -7,8 +8,8 @@ unset HOME
 
 APACHE_CONFDIR=/usr/local/etc/apache24
 
-export APACHE_RUN_USER={{ salt['pillar.get']('apache:user', 'www') }}
-export APACHE_RUN_GROUP={{ salt['pillar.get']('apache:group', 'www') }}
+export APACHE_RUN_USER={{ apache.user }}
+export APACHE_RUN_GROUP={{ apache.group }}
 export APACHE_RUN_DIR={{ salt['pillar.get']('apache:run_dir', '/var/run') }}
 
 ## The locale used by some modules like mod_dav

--- a/apache/init.sls
+++ b/apache/init.sls
@@ -3,6 +3,13 @@
 apache:
   pkg.installed:
     - name: {{ apache.server }}
+  group.present:
+    - name: {{ apache.group }}
+    - system: True
+  user.present:
+    - name: {{ apache.user }}
+    - gid: {{ apache.group }}
+    - system: True
   service.running:
     - name: {{ apache.service }}
     - enable: True

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -5,6 +5,8 @@
     'Gentoo': {
         'server': 'www-servers/apache',
         'service': 'apache2',
+        'user': 'apache',
+        'group': 'apache',
         'configfile': '/etc/apache2/httpd.conf',
 
         'mod_wsgi': 'www-apache/mod_wsgi',
@@ -23,6 +25,8 @@
     'Debian': {
         'server': 'apache2',
         'service': 'apache2',
+        'user': 'www-data',
+        'group': 'www-data',
         'configfile': '/etc/apache2/apache2.conf',
         'portsfile': '/etc/apache2/ports.conf',
 
@@ -45,6 +49,8 @@
     'RedHat': {
         'server': 'httpd',
         'service': 'httpd',
+        'user': 'apache',
+        'group': 'apache',
         'configfile': '/etc/httpd/conf/httpd.conf',
 
         'mod_wsgi': 'mod_wsgi',
@@ -65,6 +71,8 @@
     'Suse': {
         'server': 'apache2',
         'service': 'apache2',
+        'user': 'apache',
+        'group': 'apache',
         'configfile': '/etc/apache2/httpd.conf',
 
         'mod_wsgi': 'apache2-mod_wsgi',
@@ -83,6 +91,8 @@
     'FreeBSD': {
         'server': 'apache22',
         'service': 'apache22',
+        'user': 'www',
+        'group': 'www',
         'configfile': '/usr/local/etc/apache22/httpd.conf',
         'portsfile': '/usr/local/etc/apache22/ports.conf',
 

--- a/apache/mod_pagespeed.sls
+++ b/apache/mod_pagespeed.sls
@@ -24,12 +24,12 @@ a2enmod pagespeed:
   file:
     - directory
     - makedirs: true
-    - user: {{ salt['pillar.get']('apache:user', 'www-data') }}
-    - group: {{ salt['pillar.get']('apache:group', 'www-data') }}
+    - user: {{ apache.user }}
+    - group: {{ apache.group }}
     - require:
       - pkg: libapache2-mod-pagespeed
-      - user: {{ salt['pillar.get']('apache:user', 'www-data') }}
-      - group: {{ salt['pillar.get']('apache:group', 'www-data') }}
+      - user: {{ apache.user }}
+      - group: {{ apache.group }}
 {% endfor %}
 
 # Here we hardcode a logrotate entry to take care of the logs

--- a/pillar.example
+++ b/pillar.example
@@ -5,6 +5,8 @@ apache:
   lookup:
     server: apache2
     service: apache2
+    user: some_system_user
+    group: some_system_group
 
     vhostdir: /etc/apache2/sites-available
     confdir: /etc/apache2/conf.d


### PR DESCRIPTION
Some state files and templates refer to `apache:user` and or `apache:group` which are not even mentioned or declared anywhere.

The state file `mod_pagespeed.sls` required these two as `user` and `group` resources, making the state fail on dependencies.

**Summary of Changes**
 * Added sane defaults for these 2 attributes
 * Added a couple of resouces in the `init.sls` state file to make sure the existing states pass.
 * Updated `pillar.example` accordingly.

**Testing**
 * Tested on Debian / CentOS
