### PR TITLE
Fix wsgi.conf uncomment for RedHat based OS

### DIFF
--- a/apache/mod_wsgi.sls
+++ b/apache/mod_wsgi.sls
@@ -9,10 +9,11 @@ mod_wsgi:
     - require:
       - pkg: apache
 
-{% if grains.get('os_family') == 'RedHat' and salt['file.file_exists']('/etc/httpd/conf.d/wsgi.conf') %}
+{% if grains.get('os_family') == 'RedHat' %}
 /etc/httpd/conf.d/wsgi.conf:
   file.uncomment:
     - regex: LoadModule
+    - onlyif: test -f /etc/httpd/conf.d/wsgi.conf
     - require:
       - pkg: mod_wsgi
 {% endif %}


### PR DESCRIPTION
I've made a mistake in this PR: #172 

The problem will be on RedHat based systems in case if `mod_wsgi` is installed and `wsgi.conf` is created. It won't be uncommented for the first time because Jinja is executed before `mod_wsgi` is actually installed. So `file.uncomment` state won't be present for the first time in any cases. 
This PR fixes it.