### PR TITLE
in RH, vhosts.d doesnt exisit, this makes it

### DIFF
--- a/apache/init.sls
+++ b/apache/init.sls
@@ -14,6 +14,10 @@ apache:
     - name: {{ apache.service }}
     - enable: True
 
+{{ apache.vhostdir }}:
+  file.directory:
+      - makedirs: True
+
 # The following states are inert by default and can be used by other states to
 # trigger a restart or reload as needed.
 apache-reload:


### PR DESCRIPTION
**Summary of Changes**
Make vhosts.d dir if it doesnt exisit, like on Redhat
 * Issue summary 
In Redhat this dir doesnt exisit
**Testing**
 - Ran `make`, I am not sure how to run these tests. Please add it to the README
 - Tested in Vagrant
Yes.
 - Tested on OS 
Yes Tested on Centos 7.2 and 7.3
