### PR TITLE
Replaced Apache 2.4 syntax in RedHat Apache 2.2 config (fixes #115)

### DIFF
--- a/apache/files/RedHat/apache-2.2.config.jinja
+++ b/apache/files/RedHat/apache-2.2.config.jinja
@@ -167,7 +167,8 @@ ServerAdmin root@localhost
 #
 <Directory />
     AllowOverride none
-    Require all denied
+    Order deny,allow
+    Deny from all
 </Directory>
 
 #
@@ -190,7 +191,8 @@ DocumentRoot "/var/www/html"
 <Directory "/var/www">
     AllowOverride None
     # Allow open access:
-    Require all granted
+    Order allow,deny
+    Allow from all
 </Directory>
 
 # Further relax access to the default document root:
@@ -219,7 +221,8 @@ DocumentRoot "/var/www/html"
     #
     # Controls who can get stuff from this server.
     #
-    Require all granted
+    Order allow,deny
+    Allow from all
 </Directory>
 
 #
@@ -235,7 +238,8 @@ DocumentRoot "/var/www/html"
 # viewed by Web clients. 
 #
 <Files ".ht*">
-    Require all denied
+    Order deny,allow
+    Deny from all
 </Files>
 
 #
@@ -324,7 +328,8 @@ LogLevel warn
 <Directory "/var/www/cgi-bin">
     AllowOverride None
     Options None
-    Require all granted
+    Order allow,deny
+    Allow from all
 </Directory>
 
 <IfModule mime_module>


### PR DESCRIPTION
**Summary of Changes**
The RedHat Apache 2.2 config template contains `Require all` statements for Apache 2.4, which I've replaced with 2.2-compatible `Allow` and `Deny` statements

**Testing**
Tested in Vagrant with CentOS 6.9
