### PR TITLE
Replaced use_require with Apache version check (fixes #188)

### DIFF
--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -20,7 +20,6 @@
         'logdir': '/var/log/apache2',
         'logrotatedir': '/etc/logrotate.d/apache2',
         'wwwdir': '/var/www',
-        'use_require': False,
     },
     'Debian': {
         'server': 'apache2',
@@ -46,7 +45,6 @@
         'logdir': '/var/log/apache2',
         'logrotatedir': '/etc/logrotate.d/apache2',
         'wwwdir': '/srv',
-        'use_require': False,
     },
     'RedHat': {
         'server': 'httpd',
@@ -69,7 +67,6 @@
         'logrotatedir': '/etc/logrotate.d/httpd',
         'wwwdir': '/var/www',
         'default_charset': 'UTF-8',
-        'use_require': False,
     },
     'Suse': {
         'server': 'apache2',
@@ -89,7 +86,6 @@
         'default_site_ssl': 'vhost-ssl.template',
         'logdir': '/var/log/apache2',
         'wwwdir': '/srv/www',
-        'use_require': True,
     },
     'FreeBSD': {
         'server': 'apache22',
@@ -113,83 +109,70 @@
         'default_site_ssl': 'default-ssl',
         'logdir': '/var/log/',
         'wwwdir': '/usr/local/www/apache22/',
-        'use_require': False,
     },
 }, merge=salt['grains.filter_by']({
     'precise': {
         'confext': '',
         'default_site': 'default',
         'default_site_ssl': 'default-ssl',
-        'use_require': True,
     },
     'trusty': {
         'confext': '.conf',
         'default_site': '000-default.conf',
         'default_site_ssl': 'default-ssl.conf',
-        'use_require': True,
     },
     'utopic': {
         'confext': '.conf',
         'default_site': '000-default.conf',
         'default_site_ssl': 'default-ssl.conf',
-        'use_require': True,
     },
     'vivid': {
         'confext': '.conf',
         'default_site': '000-default.conf',
         'default_site_ssl': 'default-ssl.conf',
-        'use_require': True,
     },
     'wily': {
         'confext': '.conf',
         'default_site': '000-default.conf',
         'default_site_ssl': 'default-ssl.conf',
-        'use_require': True,
     },
     'xenial': {
         'confext': '.conf',
         'default_site': '000-default.conf',
         'default_site_ssl': 'default-ssl.conf',
-        'use_require': True,
     },
     'yakkety': {
         'confext': '.conf',
         'default_site': '000-default.conf',
         'default_site_ssl': 'default-ssl.conf',
-        'use_require': True,
     },
     'zesty': {
         'confext': '.conf',
         'default_site': '000-default.conf',
         'default_site_ssl': 'default-ssl.conf',
-        'use_require': True,
     },
     'artful': {
         'confext': '.conf',
         'default_site': '000-default.conf',
         'default_site_ssl': 'default-ssl.conf',
-        'use_require': True,
     },
     'jessie': {
         'wwwdir': '/var/www',
         'confext': '.conf',
         'default_site': '000-default.conf',
         'default_site_ssl': 'default-ssl.conf',
-        'use_require': True,
     },
     'stretch': {
         'wwwdir': '/var/www',
         'confext': '.conf',
         'default_site': '000-default.conf',
         'default_site_ssl': 'default-ssl.conf',
-        'use_require': True,
     },
     'buster': {
         'wwwdir': '/var/www',
         'confext': '.conf',
         'default_site': '000-default.conf',
         'default_site_ssl': 'default-ssl.conf',
-        'use_require': True,
     },
 }, grain='oscodename', merge=salt['grains.filter_by'](
     osfingermap

--- a/apache/vhosts/proxy.tmpl
+++ b/apache/vhosts/proxy.tmpl
@@ -76,7 +76,7 @@
         'Dav': loc.get('Dav', False),
     } %}
     <Location "{{ path }}">
-      {% if apache.use_require %}
+      {% if apache.version == '2.4' %}
       {%- if lvals.get('Require') != False %}Require {{lvals.Require}}{% endif %}
       {% else %}
       {%- if lvals.get('Order') != False %}Order {{ lvals.Order }}{% endif %}
@@ -93,7 +93,7 @@
         'Dav': locmat.get('Dav', False),
     } %}
     <LocationMatch "{{ regpath }}">
-      {% if apache.use_require %}
+      {% if apache.version == '2.4' %}
       {%- if lmvals.get('Require') != False %}Require {{lmvals.Require}}{% endif %}
       {% else %}
       {%- if lmvals.get('Order') != False %}Order {{ lmvals.Order }}{% endif %}

--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -88,7 +88,7 @@
 
     <Directory "{{ path }}">
         {% if dvals.get('Options') != False %}Options {{ dvals.Options }}{% endif %}
-        {% if map.use_require %}
+        {% if map.version == '2.4' %}
         {% if dvals.get('Require') != False %}Require {{dvals.Require}}{% endif %}
         {% else %}
         {% if dvals.get('Order') != False %}Order {{ dvals.Order }}{% endif %}
@@ -112,7 +112,7 @@
     } %}
 
     <Location "{{ path }}">
-        {% if map.use_require %}
+        {% if map.version == '2.4' %}
         {%- if lvals.get('Require') != False %}Require {{lvals.Require}}{% endif %}
         {% else %}
         {%- if lvals.get('Order') != False %}Order {{ lvals.Order }}{% endif %}


### PR DESCRIPTION
**Summary of Changes**
Virtual host config templates no longer rely on `use_require` to determine whether to use Apache 2.2 or 2.4 syntax. Instead, a simple version check is used.

**Testing**
Tested on Vagrant with CentOS 6.9 (Apache 2.2) and CentOS 7 (Apache 2.4)