### PR TITLE
add suse support to apache_modules

### DIFF
--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -52,7 +52,7 @@ find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^\s*LoadModule.{{ m
       - module: apache-restart
 {% endfor %}
 
-{% elif grains['os_family']=="Suse" %}
+{% elif salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}
 
 include:
   - apache


### PR DESCRIPTION
**Summary of Changes**
 * Suse supports a2enmod and a2dismod slightly different
 - Added a2enmod support and test if /etc/sysconfig/apache2 is updated
 - Added a2dismod support and test if /etc/sysconfig/apache2 is updated
**Testing**
 - Tested on OS opensuse Leap and Tumbleweed
