### PR TITLE
mod_fastcgi: use oscodename grain / call for testers

### DIFF
--- a/apache/mod_fastcgi.sls
+++ b/apache/mod_fastcgi.sls
@@ -15,7 +15,7 @@ mod-fastcgi:
 
 repo-fastcgi:
   pkgrepo.managed:
-    - name: "deb http://httpredir.debian.org/debian jessie"
+    - name: "deb http://httpredir.debian.org/debian {{ grains['oscodename'] }}"
     - file: /etc/apt/sources.list.d/non-free.list
     - comps: non-free
 


### PR DESCRIPTION
Just noticed that `mod_fastcgi` is hardcoded to Debian Jessie.
https://github.com/saltstack-formulas/apache-formula/blob/69bb7744c879ec988ff9e6cf5388db6394a4748a/apache/mod_fastcgi.sls#L18

I propose replacing this with the `oscodename` grain.

But there's a problem: I've got no setup to test this on. :-)
So please help me out here: I've you're using Debian, give this PR a try.