### PR TITLE
Add setting that allows deployers to override the default mod_ssl

### DIFF
--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -53,6 +53,7 @@
         'group': 'apache',
         'configfile': '/etc/httpd/conf/httpd.conf',
 
+        'mod_ssl': 'mod_ssl',
         'mod_wsgi': 'mod_wsgi',
         'conf_mod_wsgi': '/etc/httpd/conf.d/wsgi.conf',
         'mod_php5': 'php',

--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -19,6 +19,7 @@ a2enmod mod_ssl:
 
 mod_ssl:
   pkg.installed:
+    - name: {{ apache.mod_ssl }}
     - require:
       - pkg: apache
     - watch_in:


### PR DESCRIPTION
**Summary of Changes**

Other states in this formula allow changing the Apache httpd or module
package on RHEL/CentOS, e.g., one may use packages from the httpd24
SCL to install newer versions than in the base repositories.  This
changes the apache.mod_ssl SLS to match them.

  - patched `apache/map.jinja` to set the default mod_ssl package on RHEL/CentOS to `mod_ssl`
  - patched `apache/mod_ssl.sls` to install the package based on the value of `apache.mod_ssl`

**Testing**

  - tested on CentOS Linux 7.4
