### PR TITLE
Enhancement: Allow Skipping of service manipulation via pillar

### DIFF
--- a/apache/init.sls
+++ b/apache/init.sls
@@ -10,6 +10,8 @@ apache:
     - name: {{ apache.user }}
     - gid: {{ apache.group }}
     - system: True
+  {# By default run apache service states (unless pillar is false) #}
+  {% if salt['pillar.get']('apache:manage_service_states', True) %}
   service.running:
     - name: {{ apache.service }}
     - enable: True
@@ -25,3 +27,17 @@ apache-restart:
   module.wait:
     - name: service.restart
     - m_name: {{ apache.service }}
+
+  {% else %}
+
+apache-reload:
+  test.show_notification:
+    - name: Skipping reload per user request
+    - text: Pillar manage_service_states is False
+
+apache-restart:
+  test.show_notification:
+    - name: Skipping restart per user request
+    - text: Pillar manage_service_states is False
+
+  {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,9 @@
 # ``apache`` formula configuration:
 apache:
 
+  # By default apache restart/reload states run (false skips)
+  manage_service_states: True
+
   # lookup section overrides ``map.jinja`` values
   lookup:
     server: apache2


### PR DESCRIPTION
By default apache service is aggressively managed by salt and  this behaviour is highly desirable by default.  Nevertheless some User Case (UC) will arise where manipulation of the apache service state by Salt should be turned OFF during formula execution.  See RFE #186 

This PR is an enhancement to allow apache service manipulation to be explicitly disabled via pillar during execution of the formula. The Pillar **`apache.lookup.manage_service_states`** is introduced to support the feature and code updated accordingly.

**Example Pillar**
```
apache:
  lookup:
    version: '2.4'
    manage_service_states: False      (Variations accepted: "False", 'False', False, false, etc)
```

**Salt Output**

```
          ID: apache-reload
    Function: test.show_notification
        Name: Skipping reload per user request 
      Result: True 
     Comment: Pillar manage_service_states is False
     Started: 13:52:35.720342
    Duration: 0.281 ms
     Changes:   
---------- 
          ID: apache-restart 
    Function: test.show_notification
        Name: Skipping restart per user request
      Result: True 
     Comment: Pillar manage_service_states is False
     Started: 13:52:35.720721
    Duration: 0.25 ms
     Changes: 

Summary for local
------------
Succeeded: 9
Failed:    0
------------
Total states run:     9
```

In all other case the formula will execute as normal. Default behaviour (manage_service_states: True) is preserved and managed by `map.jinja` and `init.sls` code. 
 
```
     ID: apache
    Function: service.running
        Name: httpd
      Result: True
     Comment: The service httpd is already running
     Started: 13:50:29.009931
    Duration: 24.971 ms
     Changes:
             ----------
          ID: apache-reload
    Function: module.wait
        Name: service.reload
      Result: True
     Comment:
     Started: 13:50:29.035686
    Duration: 0.347 ms
     Changes:

               ----------
          ID: apache-restart
    Function: module.wait
        Name: service.restart
      Result: True
     Comment:
     Started: 13:50:29.037067
    Duration: 0.455 ms
     Changes:

        Summary for local
          -------------
           Succeeded: 10
           Failed:     0
             -------------
           Total states run:     10
           Total run time:  614.769 ms
```