### PR TITLE
Modified standard state and template to specify owner

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -24,10 +24,12 @@ include:
 {% if site.get('DocumentRoot') != False %}
 {{ id }}-documentroot:
   file.directory:
-    - unless: test -d {{ documentroot }}
-    - name: {{ documentroot }}
+    - unless: test -d {{ documentroot.path }}
+    - name: {{ documentroot.path }}
     - makedirs: True
     - allow_symlink: True
+    - user: {{ documentroot.owner }}
+    - group: {{ documentroot.group }}
 {% endif %}
 
 {% if grains.os_family == 'Debian' %}

--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -54,7 +54,7 @@
     {% if site.get('ErrorLog') != False -%}ErrorLog {{ vals.ErrorLog }}{% endif %}
     {% if site.get('CustomLog') != False -%}CustomLog {{ vals.CustomLog }} {{ vals.LogFormat }}{% endif %}
 
-    {% if site.get('DocumentRoot') != False -%}DocumentRoot {{ vals.DocumentRoot }}{% endif %}
+    {% if site.get('DocumentRoot') != False -%}DocumentRoot {{ vals.DocumentRoot.path }}{% endif %}
     {% if site.get('VirtualDocumentRoot') -%}VirtualDocumentRoot {{ vals.VirtualDocumentRoot }}{% endif %}
 
     {% if site.get('Timeout') != False and site.get('Timeout') != None %}Timeout {{ vals.Timeout }}{% endif %}


### PR DESCRIPTION
**Summary of Changes**
The actual apache2 formula creates DocumentRoot with root as owner, but the apache2 process is running as www-data. This works, but when the webserver has to write in the directory, it can't.

So I changed the state and the template to take more arguments for the DocumentRoot. Your pillar file will now look like this:

```
apache:
  sites:
    example.com:
      enabled: True
      template_file: salt://apache/vhosts/standard.tmpl
      
      ServerName: example.com
      ServerAlias: www.example.com
      
      LogLevel: warn
      ErrorLog: /var/log/apache2/example.com-error.log
      CustomLog: /var/log/apache2/example.com-access.log

      DocumentRoot: 
        path: /var/www/example.com
        owner: www-data
        group: www-data
      
      Directory:
        default:
          Options: -Indexes +FollowSymLinks
          Require: all granted
          AllowOverride: All

```

**Testing**
 - Tested and works on Debian 9 (Saltmaster and minion)
