### PR TITLE
Split Logformat and CustomLog Directive to avoid syntax error on RedHat

### DIFF
--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -52,7 +52,8 @@
 
     {% if site.get('LogLevel') != False -%}LogLevel {{ vals.LogLevel }}{% endif %}
     {% if site.get('ErrorLog') != False -%}ErrorLog {{ vals.ErrorLog }}{% endif %}
-    {% if site.get('CustomLog') != False -%}CustomLog {{ vals.CustomLog }} {{ vals.LogFormat }}{% endif %}
+    {% if site.get('LogFormat') != False -%}LogFormat {{ vals.LogFormat }}{% endif %}
+    {% if site.get('CustomLog') != False -%}CustomLog {{ vals.CustomLog }} {% endif %}
 
     {% if site.get('DocumentRoot') != False -%}DocumentRoot {{ vals.DocumentRoot }}{% endif %}
     {% if site.get('VirtualDocumentRoot') -%}VirtualDocumentRoot {{ vals.VirtualDocumentRoot }}{% endif %}


### PR DESCRIPTION
**Summary of Changes**
 * Issue summary 
 - issue-199 : On standard.tmpl Customlog and Logformat directive leads to an error
**Testing**
 - Tested on RedHat EL 7.4 with apache http 2.4.6 