### PR TITLE
Fix CustomLog default values in templates

### DIFF
--- a/apache/vhosts/minimal.tmpl
+++ b/apache/vhosts/minimal.tmpl
@@ -12,8 +12,9 @@
 
     'LogLevel': site.get('LogLevel', 'warn'),
     'ErrorLog': site.get('ErrorLog', '{0}/{1}-error.log'.format(map.logdir, sitename)),
-    'CustomLog': site.get('CustomLog', '{0}/{1}-access.log'.format(map.logdir, sitename)),
+    'CustomLog': site.get('CustomLog', '{0}/{1}-access.log {1}'.format(map.logdir, sitename)),
     'LogFormat': site.get('LogFormat', '"%h %l %u %t \\\"%r\\\" %>s %b"'),
+    'LogFormat': site.get('LogFormat', '"%h %l %u %t \\\"%r\\\" %>s %b" {0}'.format(sitename)),
 
 
     'DocumentRoot': site.get('DocumentRoot', '{0}/{1}'.format(map.wwwdir, sitename))

--- a/apache/vhosts/proxy.tmpl
+++ b/apache/vhosts/proxy.tmpl
@@ -15,7 +15,8 @@
     'LogLevel': site.get('LogLevel', 'warn'),
     'ErrorLog': site.get('ErrorLog', '{0}/{1}-error.log'.format(map.logdir, sitename)),
     'LogFormat': site.get('LogFormat', '"%a %l %u %t \\"%r\\" %>s %O \\"%{Referer}i\\" \\"%{User-Agent}i\\""'),
-    'CustomLog': site.get('CustomLog', '{0}/{1}-access.log'.format(map.logdir, sitename)),
+    'LogFormat': site.get('LogFormat', '"%a %l %u %t \\"%r\\" %>s %O \\"%{Referer}i\\" \\"%{User-Agent}i\\"" {0}'.format(sitename)),
+    'CustomLog': site.get('CustomLog', '{0}/{1}-access.log {1}'.format(map.logdir, sitename)),
 
     'ProxyRequests': site.get('ProxyRequests', 'Off'),
     'ProxyPreserveHost': site.get('ProxyPreserveHost', 'On'),

--- a/apache/vhosts/redirect.tmpl
+++ b/apache/vhosts/redirect.tmpl
@@ -16,7 +16,8 @@
     'LogLevel': site.get('LogLevel', 'warn'),
     'ErrorLog': site.get('ErrorLog', '{0}/{1}-error.log'.format(map.logdir, sitename)),
     'LogFormat': site.get('LogFormat', '"%h %l %u %t \\\"%r\\\" %>s %O"'),
-    'CustomLog': site.get('CustomLog', '{0}/{1}-access.log'.format(map.logdir, sitename)),
+    'LogFormat': site.get('LogFormat', '"%h %l %u %t \\\"%r\\\" %>s %O" {0}'.format(sitename)),
+    'CustomLog': site.get('CustomLog', '{0}/{1}-access.log {1}'.format(map.logdir, sitename)),
     
     'RedirectSource': site.get('RedirectSource', '/'),
     'RedirectTarget': site.get('RedirectTarget', 'https://{0}/'.format(sitename)),

--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -17,7 +17,8 @@
     'LogLevel': site.get('LogLevel', 'warn'),
     'ErrorLog': site.get('ErrorLog', '{0}/{1}-error.log'.format(map.logdir, sitename)),
     'LogFormat': site.get('LogFormat', '"%h %l %u %t \\\"%r\\\" %>s"'),
-    'CustomLog': site.get('CustomLog', '{0}/{1}-access.log'.format(map.logdir, sitename)),
+    'LogFormat': site.get('LogFormat', '"%h %l %u %t \\\"%r\\\" %>s" {0}'.format(sitename)),
+    'CustomLog': site.get('CustomLog', '{0}/{1}-access.log {1}'.format(map.logdir, sitename)),
 
     'DocumentRoot': site.get('DocumentRoot', '{0}/{1}'.format(map.wwwdir, sitename)),
     'VirtualDocumentRoot': site.get('VirtualDocumentRoot'),


### PR DESCRIPTION
Fixes syntax error described in #199. (`CustomLog takes two or three arguments ...`)

Tested on Ubuntu 16.04 and FreeBSD 10.3.