### PR TITLE
Replace apache.conf_mod_wsgi if statement syntax (fixes #209)

### DIFF
--- a/apache/mod_wsgi.sls
+++ b/apache/mod_wsgi.sls
@@ -9,7 +9,7 @@ mod_wsgi:
     - require:
       - pkg: apache
 
-{% if apache.conf_mod_wsgi %}
+{% if 'conf_mod_wsgi' in apache %}
 {{ apache.conf_mod_wsgi }}:
   file.uncomment:
     - regex: LoadModule


### PR DESCRIPTION
**Summary of Changes**
Rendering the mod_wsgi state would throw the following error:

```
Rendering SLS 'base:apache.mod_wsgi' failed: Jinja variable 'dict object' has no attribute 'conf_mod_wsgi'
```

Updating the syntax of the if statement allows the state to compile.

**Testing**
Tested on Ubuntu 16.04