### PR TITLE
Updated Travis/Kitchen tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,23 +1,20 @@
 ---
 driver:
-  name: vagrant
+  name: docker
+  use_sudo: false
+  privileged: true
+  require_chef_omnibus: false
 
 platforms:
-  - name: debian-jessie64
-    driver_config:
-      box: ssplatt/salt-deb-8
   - name: centos-7
-    driver_config:
-      box: rchrd/centos-7-x64-salt
-  - name: centos-6
-    driver_config:
-      box: rchrd/centos-6-x64-salt
+  - name: ubuntu-16.04
+  - name: debian-9
 
 provisioner:
   name: salt_solo
-  salt_version: 2015.8.8
+  formula: apache
+  require_chef: false
   data_path: test/shared
-  is_file_root: true
   pillars:
     top.sls:
       base:
@@ -25,6 +22,7 @@ provisioner:
           - apache
     apache.sls:
       apache:
+        manage_service_states: False
         mod_security:
           crs_install: True
           manage_config: True
@@ -39,16 +37,20 @@ provisioner:
           sec_debug_log_level: '3'
 
 suites:
-  - name: apache
-    provisioner:
-      state_top:
-        base:
-          '*':
-            - apache
-  - name: mod_security
+  - name: default
     provisioner:
       state_top:
         base:
           '*':
             - apache
             - apache.mod_security
+  - name: apache_norestart
+    provisioner:
+      state_top:
+        base:
+          '*':
+            - apache
+      pillars:
+        apache.sls:
+          apache:
+            manage_service_states: False

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+language: python
+services: 
+  - docker
+
+before_install:
+  - bundle install
+
+env:
+  matrix:
+    - INSTANCE: default-centos-7
+    - INSTANCE: default-ubuntu-1604
+    - INSTANCE: default-debian-9
+
+script:
+  - bundle exec kitchen verify ${INSTANCE}

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "test-kitchen", '>=1.2.1'
+gem "kitchen-docker"
+gem "kitchen-salt", ">=0.0.11"
+gem "kitchen-inspec"

--- a/apache/init.sls
+++ b/apache/init.sls
@@ -10,6 +10,8 @@ apache:
     - name: {{ apache.user }}
     - gid: {{ apache.group }}
     - system: True
+  {# By default run apache service states (unless pillar is false) #}
+  {% if salt['pillar.get']('apache:manage_service_states', True) %}
   service.running:
     - name: {{ apache.service }}
     - enable: True
@@ -25,3 +27,17 @@ apache-restart:
   module.wait:
     - name: service.restart
     - m_name: {{ apache.service }}
+
+  {% else %}
+
+apache-reload:
+  test.show_notification:
+    - name: Skipping reload per user request
+    - text: Pillar manage_service_states is False
+
+apache-restart:
+  test.show_notification:
+    - name: Skipping restart per user request
+    - text: Pillar manage_service_states is False
+
+  {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,9 @@
 # ``apache`` formula configuration:
 apache:
 
+  # By default apache restart/reload states run (false skips)
+  manage_service_states: True
+
   # lookup section overrides ``map.jinja`` values
   lookup:
     server: apache2


### PR DESCRIPTION
**Summary of Changes**
 * This PR updates travis/kitchen tests

**Testing**
 - Passed in Docker (Ubuntu/Centos/Debian9) on travis-ci

**Prerequisites**
  - Enable saltstack-formulas/apache in travis-ci

