### PR TITLE
Fix mod_fastcgi, mod_php5, and pkgrepo states

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Enables mod_cgi. (FreeBSD only)
 ``apache.mod_fcgid``
 --------------------
 
-Installs and enables the mod_fcgid module
+Installs and enables the mod_fcgid module (Debian only)
 
 ``apache.mod_fastcgi``
 --------------------
@@ -129,7 +129,7 @@ Allows you to install the basic Core Rules (CRS) and some basic configuration fo
 This state can create symlinks based on basic Core Rules package. (Debian only)
 Or it can distribute a mod_security rule file and place it /etc/modsecurity/
 
-``mod_socache_shmcb``
+``apache.mod_socache_shmcb``
 ---------------------
 
 Enables mod_socache_shmcb. (FreeBSD only)

--- a/apache/mod_fastcgi.sls
+++ b/apache/mod_fastcgi.sls
@@ -15,8 +15,9 @@ mod-fastcgi:
 
 repo-fastcgi:
   pkgrepo.managed:
-    - name: "deb http://httpredir.debian.org/debian {{ grains['oscodename'] }}"
+    - name: "deb http://ftp.us.debian.org/debian {{ grains['oscodename'] }}"
     - file: /etc/apt/sources.list.d/non-free.list
+    - onlyif: grep Debian /proc/version >/dev/null 2>&1
     - comps: non-free
 
 a2enmod fastcgi:


### PR DESCRIPTION
This PR fixes apache.mod_fastcgi state failure.

**Summary of Changes**
 * Issue summary 
 - **State failures on Ubuntu 16.04**
```
[ERROR   ] Command '['apt-get', '-q', 'update']' failed with return code: 100
[ERROR   ] stdout: Hit:1 http://us.archive.ubuntu.com/ubuntu xenial InRelease
[ERROR   ] stderr: W: The repository 'http://httpredir.debian.org/debian xenial Release' does not have a Release file.
[ERROR   ] retcode: 100
[ERROR   ] Failed to configure repo 'deb http://httpredir.debian.org/debian xenial': W: The repository 'http://httpredir.debian.org/debian xenial Release' does not have a Release file.
[ERROR   ] Service apache2 is already enabled, and is dead
```
  **- state failures on Debian Jessie**
```
[ERROR   ] Command '['systemd-run', '--scope', 'apt-get', '-q', '-y', '-o', 'DPkg::Options::=--force-confold', '-o', 'DPkg::Options::=--force-confdef', 'install', 'libapache2-mod-fastcgi']' failed with return code: 100
[ERROR   ] stdout: Reading package lists...
Building dependency tree...
Reading state information...
Package libapache2-mod-fastcgi is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
[ERROR   ] stderr: Running as unit run-4638.scope.
E: Package 'libapache2-mod-fastcgi' has no installation candidate
[ERROR   ] retcode: 100
[ERROR   ] Problem encountered installing package(s). Additional info follows:
```

**Testing**
 - Tested in Vagrant Debian Jessie
I updated` /etc/apt/sources.list.d/non-free.list` adding working mirror.
```
deb http://httpredir.debian.org/debian jessie non-free
deb http://ftp.us.debian.org/debian jessie non-free
```
 - Tested on OS Ubuntu 16.04
Skip pkgrepo function, not required.

```
          ID: mod-fastcgi
    Function: pkg.installed
        Name: libapache2-mod-fastcgi
      Result: True
     Comment: 1 targeted package was installed/updated.
     Started: 20:45:22.054526
    Duration: 7749.854 ms
     Changes:
              ----------
              libapache2-mod-fastcgi:
                  ----------
                  new:
                      2.4.7~0910052141-1.1+deb8u1
                  old:
```