### PR TITLE
Change root group references to use GID 0

### DIFF
--- a/apache/certificates.sls
+++ b/apache/certificates.sls
@@ -14,7 +14,7 @@ apache_cert_config_{{ site }}_key_file:
     - makedirs: True
     - mode: 600
     - user: root
-    - group: root
+    - group: 0
     - watch_in:
       - module: apache-reload
 {% endif %}
@@ -28,7 +28,7 @@ apache_cert_config_{{ site }}_cert_file:
     - makedirs: True
     - mode: 600
     - user: root
-    - group: root
+    - group: 0
     - watch_in:
       - module: apache-reload
 {% endif %}
@@ -42,7 +42,7 @@ apache_cert_config_{{ site }}_bundle_file:
     - makedirs: True
     - mode: 600
     - user: root
-    - group: root
+    - group: 0
     - watch_in:
       - module: apache-reload
 {% endif %}

--- a/apache/mod_security/rules.sls
+++ b/apache/mod_security/rules.sls
@@ -13,7 +13,7 @@ include:
   file.symlink:
     - target: /usr/share/modsecurity-crs/{{ rule_set }}/{{ rule_name }}
     - user: root
-    - group: root
+    - group: 0
     - mode: 755
   {%- else %}
 /etc/modsecurity/{{ rule_name }}:
@@ -33,7 +33,7 @@ include:
   file.managed:
     - source: {{ path }}
     - user: root
-    - group: root
+    - group: 0
     - mode: 755
   {%- else %}
 /etc/modsecurity/{{ file }}:


### PR DESCRIPTION
**Summary of Changes**
 * On BSD the group with GID 0 is named `wheel`.
 - Rather than change the group name on a per-operating system basis, it's simpler to reference the group by GID.
 - Only change SLS files that apply to both Linux and FreeBSD.
**Testing**
 - Tested manually on FreeBSD
