### PR TITLE
DocumentRoot: fallback to SiteName like templates

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -4,7 +4,7 @@ include:
   - apache
 
 {% for id, site in salt['pillar.get']('apache:sites', {}).items() %}
-{% set documentroot = site.get('DocumentRoot', '{0}/{1}'.format(apache.wwwdir, id)) %}
+{% set documentroot = site.get('DocumentRoot', '{0}/{1}'.format(apache.wwwdir, site.get('ServerName', id))) %}
 
 {{ id }}:
   file:


### PR DESCRIPTION
Templates already fallback to SiteName before site id.
    
This attemps to be consistent with them, and avoid having to explicitly specify the DocumentRoot, when the template already does the proper inference.
