### PR TITLE
manage_security: fix file presence detection

### DIFF
--- a/apache/manage_security.sls
+++ b/apache/manage_security.sls
@@ -19,9 +19,8 @@ include:
 
 {% if grains['os_family']=="Debian" %}
 
-{% if salt['file.file_exists' ]('/etc/apache2/conf-available/security.conf') %}
 {{ security_config('/etc/apache2/conf-available/security.conf') }}
-{% endif %}
+    - onlyif: test -f '/etc/apache2/conf-available/security.conf'
 
 {% elif grains['os_family']=="FreeBSD" %}
 {{ security_config(apache.confdir+'/security.conf') }}


### PR DESCRIPTION
Detect file presence at runtime, rather than before starting/installing anything.

