### PR TITLE
vhosts/standard: allow to set docroot ownership

### DIFF
--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -26,12 +26,8 @@ include:
   file.directory:
     - name: {{ documentroot }}
     - makedirs: True
-{% if site.get('DocumentRootUser') %}
-    - user: {{ site.DocumentRootUser }}
-{% endif %}
-{% if site.get('DocumentRootGroup') %}
-    - group: {{ site.DocumentRootGroup }}
-{% endif %}
+    - user: {{ site.get('DocumentRootUser', apache.get('document_root_user'))|json }}
+    - group: {{ site.get('DocumentRootGroup', apache.get('document_root_group'))|json }}
     - allow_symlink: True
 {% endif %}
 

--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -27,6 +27,12 @@ include:
     - unless: test -d {{ documentroot }}
     - name: {{ documentroot }}
     - makedirs: True
+{% if site.get('DocumentRootUser') %}
+    - user: {{ site.DocumentRootUser }}
+{% endif %}
+{% if site.get('DocumentRootGroup') %}
+    - group: {{ site.DocumentRootGroup }}
+{% endif %}
     - allow_symlink: True
 {% endif %}
 

--- a/apache/vhosts/standard.sls
+++ b/apache/vhosts/standard.sls
@@ -24,7 +24,6 @@ include:
 {% if site.get('DocumentRoot') != False %}
 {{ id }}-documentroot:
   file.directory:
-    - unless: test -d {{ documentroot }}
     - name: {{ documentroot }}
     - makedirs: True
 {% if site.get('DocumentRootUser') %}

--- a/pillar.example
+++ b/pillar.example
@@ -71,6 +71,8 @@ apache:
       CustomLog: /path/to/logs/example.com-access.log # E.g.: /var/log/apache2/example.com-access.log
 
       DocumentRoot: /path/to/www/dir/example.com # E.g., /var/www/example.com
+      DocumentRootUser: www-data   # Force user if specified, leave it default if not
+      DocumentRootGroup: www-data  # Force group if specified, leave it default if not
 
       SSLCertificateFile: /etc/ssl/mycert.pem # if ssl is desired
       SSLCertificateKeyFile: /etc/ssl/mycert.pem.key # if key for cert is needed or in an extra file

--- a/pillar.example
+++ b/pillar.example
@@ -26,6 +26,11 @@ apache:
     # Default value for AddDefaultCharset in RedHat configuration
     default_charset: 'UTF-8'
 
+    # Should we enforce DocumentRoot user/group?
+    # Default: do not enforce
+    document_root_user: www-data   # Force user if specified, leave it default if not
+    document_root_group: null      # Do not enforce group
+
   global:
     # global apache directives
     AllowEncodedSlashes: 'On'
@@ -71,8 +76,8 @@ apache:
       CustomLog: /path/to/logs/example.com-access.log # E.g.: /var/log/apache2/example.com-access.log
 
       DocumentRoot: /path/to/www/dir/example.com # E.g., /var/www/example.com
-      DocumentRootUser: www-data   # Force user if specified, leave it default if not
-      DocumentRootGroup: www-data  # Force group if specified, leave it default if not
+      DocumentRootUser: null       # do not enforce user, defaults to lookup:document_root_user
+      DocumentRootGroup: www-data  # Force group, defaults to lookup:document_root_group
 
       SSLCertificateFile: /etc/ssl/mycert.pem # if ssl is desired
       SSLCertificateKeyFile: /etc/ssl/mycert.pem.key # if key for cert is needed or in an extra file


### PR DESCRIPTION
vhosts/standard:

* Remove what looks like a as useless `unless` on `file.directory`
* Support for `DocumentRootUser` and `DocumentRootGroup` to enforce ownership
