### PR TITLE
vhosts/standard: Directory_default to DocumentRoot

### DIFF
--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -28,7 +28,7 @@
     'Timeout': site.get('Timeout'),
     'LimitRequestFields': site.get('LimitRequestFields'),
 
-    'Directory_default': '{0}/{1}'.format(map.wwwdir, sitename),
+    'Directory_default': site.get('DocumentRoot', '{0}/{1}'.format(map.wwwdir, sitename)),
     'Directory': {
         'Options': '-Indexes +FollowSymLinks',
         'Order': 'allow,deny',

--- a/pillar.example
+++ b/pillar.example
@@ -84,7 +84,7 @@ apache:
       SSLCertificateChainFile: /etc/ssl/mycert.chain.pem # if you require a chain of server certificates file
 
       Directory:
-        # "default" is a special case; Adds ``/path/to/www/dir/example.com``
+        # "default" is a special case; uses DocumentRoot value
         # E.g.: /var/www/example.com
         default:
           Options: -Indexes +FollowSymLinks


### PR DESCRIPTION
Directory_default uses `'{0}/{1}'.format(map.wwwdir, sitename)` even if a different `DocumentRoot` is specified.

This PR changes to first try to use explicitly specified `DocumentRoot` before falling back to infered with `sitename`.