### PR TITLE
Create Apache's logdir if necessary

### DIFF
--- a/apache/config.sls
+++ b/apache/config.sls
@@ -3,6 +3,14 @@
 include:
   - apache
 
+{{ apache.logdir }}:
+  file.directory:
+    - makedirs: True
+    - require:
+      - pkg: apache
+    - watch_in:
+      - service: apache
+
 {{ apache.configfile }}:
   file.managed:
     - template: jinja


### PR DESCRIPTION
**Summary of Changes**
  - State failed because `logdir` was not present.
  - affected OS: Raspbian GNU/Linux 9.4 (stretch)

**Testing**
 - Tested on OS 
