### PR TITLE
Allow setting APACHE_SERVER_FLAGS on Suse

### DIFF
--- a/apache/flags.sls
+++ b/apache/flags.sls
@@ -1,0 +1,28 @@
+{% from "apache/map.jinja" import apache with context %}
+
+{% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}
+
+include:
+  - apache
+ 
+{% for flag in salt['pillar.get']('apache:flags:enabled', []) %}
+a2enflag {{ flag }}:
+  cmd.run:
+    - unless: egrep "^APACHE_SERVER_FLAGS=" /etc/sysconfig/apache2 | grep {{ flag }}
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+{% endfor %}
+
+{% for module in salt['pillar.get']('apache:flags:disabled', []) %}
+a2disflag -f {{ flag }}:
+  cmd.run:
+    - onlyif: egrep "^APACHE_SERVER_FLAGS=" /etc/sysconfig/apache2 | grep {{ flag }}
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+{% endfor %}
+
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -291,6 +291,12 @@ apache:
     disabled:  # List modules to disable
       - rewrite
 
+  flags:
+    enabled:  # List server flags to enable
+      - SSL
+    disabled: # List server flags to disable
+      - status
+
   # KeepAlive: Whether or not to allow persistent connections (more than
   # one request per connection). Set to "Off" to deactivate.
   keepalive: 'On'


### PR DESCRIPTION
**Summary of Changes**

* SUSE reads additional FLAGS that are used on the server start. They are
read from the APACHE_SERVER_FLAGS key, so we use a2enflag/a2disflag to
set those as we do with modules.


**Testing**
 - Tested manually on SLE/openSUSE
