### PR TITLE
mod_remoteip: enable conf independantly

### DIFF
--- a/apache/mod_remoteip.sls
+++ b/apache/mod_remoteip.sls
@@ -14,7 +14,7 @@ a2enmod remoteip:
 
 a2enconf remoteip:
   cmd.run:
-    - unless: ls /etc/apache2/mods-enabled/remoteip.load
+    - unless: ls /etc/apache2/conf-enabled/remoteip.conf
     - order: 255
     - require:
       - pkg: apache


### PR DESCRIPTION
in `mod_remoteip` on `Debian`

On debian, properly detect that **config** is not enabled before enabling it, rather than checking that the module is enabled to decide if we should still enable the config.