### PR TITLE
No automatic listener for port *

### DIFF
--- a/apache/files/Debian/ports-2.2.conf.jinja
+++ b/apache/files/Debian/ports-2.2.conf.jinja
@@ -9,7 +9,7 @@
         {%- set interfaces = site.get('interface', '*').split() %}
         {%- set port = site.get('port', 80) %}
         {%- for interface in interfaces %}
-            {%- if not site.get('exclude_listen_directive', False) %}
+            {%- if not site.get('exclude_listen_directive', False) and not port == '*' %}
                 {%- set listen_directive = interface ~ ':' ~ port %}
                 {%- if listen_directive not in listen_directives %}
                     {%- do listen_directives.append(listen_directive) %}

--- a/apache/files/Debian/ports-2.4.conf.jinja
+++ b/apache/files/Debian/ports-2.4.conf.jinja
@@ -9,7 +9,7 @@
         {%- set interfaces = site.get('interface', '*').split() %}
         {%- set port = site.get('port', 80) %}
         {%- for interface in interfaces %}
-            {%- if not site.get('exclude_listen_directive', False) %}
+            {%- if not site.get('exclude_listen_directive', False) and not port == '*' %}
                 {%- set listen_directive = interface ~ ':' ~ port %}
                 {%- if listen_directive not in listen_directives %}
                     {%- do listen_directives.append(listen_directive) %}

--- a/apache/files/FreeBSD/ports-2.4.conf.jinja
+++ b/apache/files/FreeBSD/ports-2.4.conf.jinja
@@ -9,7 +9,7 @@
         {%- set interfaces = site.get('interface', '*').split() %}
         {%- set port = site.get('port', 80) %}
         {%- for interface in interfaces %}
-            {%- if not site.get('exclude_listen_directive', False) %}
+            {%- if not site.get('exclude_listen_directive', False) and not port == '*' %}
                 {%- set listen_directive = interface ~ ':' ~ port %}
                 {%- if listen_directive not in listen_directives %}
                     {%- do listen_directives.append(listen_directive) %}

--- a/apache/files/RedHat/apache-2.4.config.jinja
+++ b/apache/files/RedHat/apache-2.4.config.jinja
@@ -50,7 +50,7 @@ ServerRoot "/etc/httpd"
         {%- set interfaces = site.get('interface', '*').split() %}
         {%- set port = site.get('port', 80) %}
         {%- for interface in interfaces %}
-            {%- if not site.get('exclude_listen_directive', False) %}
+            {%- if not site.get('exclude_listen_directive', False) and not port == '*' %}
                 {%- set listen_directive = interface ~ ':' ~ port %}
                 {%- if listen_directive not in listen_directives %}
                     {%- do listen_directives.append(listen_directive) %}


### PR DESCRIPTION
The formula currently adds a Listen directive for the port '\*' if
any configured vhost is configured to listen on :\* which does not
work and instead prevents apache from starting.

It is possible to prevent this by setting the
exclude_listen_directive pillar to True but this is a manual
workaround.

Instead, this commit excludes :* Listeners automatically.