### PR TITLE
Fix DocumentRoot on Red Hat

### DIFF
--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -71,7 +71,7 @@
         'default_site_ssl': 'default-ssl',
         'logdir': '/var/log/httpd',
         'logrotatedir': '/etc/logrotate.d/httpd',
-        'wwwdir': '/var/www',
+        'wwwdir': '/var/www/html',
         'default_charset': 'UTF-8',
         'use_require': False,
         'moddir': '/etc/httpd/conf.modules.d',


### PR DESCRIPTION
The current docroot ist set to /var/www. This is incorrect.
Fix with correct value /var/www/html.