### PR TITLE
Improve document root fix for Red Hat

### DIFF
--- a/apache/files/RedHat/apache-2.2.config.jinja
+++ b/apache/files/RedHat/apache-2.2.config.jinja
@@ -28,7 +28,7 @@
 # same ServerRoot for multiple httpd daemons, you will need to change at
 # least PidFile.
 #
-ServerRoot "/etc/httpd"
+ServerRoot "{{ apache.get('serverroot', '/etc/httpd') }}"
 
 #
 # Listen: Allows you to bind Apache to specific IP addresses and/or
@@ -183,12 +183,12 @@ ServerAdmin root@localhost
 # documents. By default, all requests are taken from this directory, but
 # symbolic links and aliases may be used to point to other locations.
 #
-DocumentRoot "/var/www/html"
+DocumentRoot "{{ apache.get('docroot', apache.wwwdir + '/html') }}"
 
 #
-# Relax access to content within /var/www.
+# Relax access to content within {{ apache.wwwdir }}.
 #
-<Directory "/var/www">
+<Directory "{{ apache.wwwdir }}">
     AllowOverride None
     # Allow open access:
     Order allow,deny
@@ -196,7 +196,7 @@ DocumentRoot "/var/www/html"
 </Directory>
 
 # Further relax access to the default document root:
-<Directory "/var/www/html">
+<Directory "{{ apache.get('docroot', apache.wwwdir + '/html') }}">
     #
     # Possible values for the Options directive are "None", "All",
     # or any combination of:
@@ -317,15 +317,15 @@ LogLevel warn
     # client.  The same rules about trailing "/" apply to ScriptAlias
     # directives as to Alias.
     #
-    ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+    ScriptAlias /cgi-bin/ "{{ apache.wwwdir }}/cgi-bin/"
 
 </IfModule>
 
 #
-# "/var/www/cgi-bin" should be changed to whatever your ScriptAliased
+# "{{ apache.wwwdir }}/cgi-bin/" should be changed to whatever your ScriptAliased
 # CGI directory exists, if you have that configured.
 #
-<Directory "/var/www/cgi-bin">
+<Directory "{{ apache.wwwdir }}/cgi-bin/">
     AllowOverride None
     Options None
     Order allow,deny

--- a/apache/files/RedHat/apache-2.4.config.jinja
+++ b/apache/files/RedHat/apache-2.4.config.jinja
@@ -32,7 +32,7 @@
 # same ServerRoot for multiple httpd daemons, you will need to change at
 # least PidFile.
 #
-ServerRoot "/etc/httpd"
+ServerRoot "{{ apache.get('serverroot', '/etc/httpd') }}"
 
 #
 # Listen: Allows you to bind Apache to specific IP addresses and/or
@@ -148,19 +148,19 @@ ServerAdmin root@localhost
 # documents. By default, all requests are taken from this directory, but
 # symbolic links and aliases may be used to point to other locations.
 #
-DocumentRoot "{{ apache.wwwdir }}"
+DocumentRoot "{{ apache.get('docroot', apache.wwwdir + '/html') }}"
 
 #
-# Relax access to content within /var/www.
+# Relax access to content within {{ apache.wwwdir }}.
 #
-<Directory "/var/www">
+<Directory "{{ apache.wwwdir }}">
     AllowOverride None
     # Allow open access:
     Require all granted
 </Directory>
 
 # Further relax access to the default document root:
-<Directory "{{ apache.wwwdir }}">
+<Directory "{{ apache.get('docroot', apache.wwwdir + '/html') }}">
     #
     # Possible values for the Options directive are "None", "All",
     # or any combination of:
@@ -279,15 +279,15 @@ LogLevel warn
     # client.  The same rules about trailing "/" apply to ScriptAlias
     # directives as to Alias.
     #
-    ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+    ScriptAlias /cgi-bin/ "{{ apache.wwwdir }}/cgi-bin/"
 
 </IfModule>
 
 #
-# "/var/www/cgi-bin" should be changed to whatever your ScriptAliased
+# "{{ apache.wwwdir }}/cgi-bin/" should be changed to whatever your ScriptAliased
 # CGI directory exists, if you have that configured.
 #
-<Directory "/var/www/cgi-bin">
+<Directory "{{ apache.wwwdir }}/cgi-bin/">
     AllowOverride None
     Options None
     Require all granted

--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -71,7 +71,7 @@
         'default_site_ssl': 'default-ssl',
         'logdir': '/var/log/httpd',
         'logrotatedir': '/etc/logrotate.d/httpd',
-        'wwwdir': '/var/www/html',
+        'wwwdir': '/var/www',
         'default_charset': 'UTF-8',
         'use_require': False,
         'moddir': '/etc/httpd/conf.modules.d',


### PR DESCRIPTION
The docroot fix from PR#240 worked fine for default servers.
But as soon as one uses vhosts this broke as the vhosts were
created under the docroot in /var/www/html rather than the better
/var/www.

Fix this by differentiating between docroot and wwwdir.
Further allow to override both in Red Hat-style configs.
The override allows to reuse this formula for the softwarecollections
rpms.

**Summary of Changes**
 * Issue summary 
 - Indented line 1
 - Indented line 2
**Testing**
 - Ran `make`
 - Tested in Vagrant
 - Tested on OS 
