### PR TITLE
Fix hardcoded path

### DIFF
--- a/apache/config.sls
+++ b/apache/config.sls
@@ -57,7 +57,7 @@ include:
 {% endif %}
 
 {% if grains['os_family']=="RedHat" %}
-/etc/httpd/conf.d/welcome.conf:
+{{ apache.confdir }}/welcome.conf:
   file.absent:
     - require:
       - pkg: apache


### PR DESCRIPTION
The config.sls state uses a hardcoded file path for the welcome
config.
Use the confdir variable to build the path instead to allow for
overrides.