### PR TITLE
Delete Red Hat provided ssl.conf

### DIFF
--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -33,6 +33,13 @@ mod_ssl:
     - watch_in:
       - module: apache-restart
 
+{{ apache.confdir }}/ssl.conf:
+  file.absent:
+    - require:
+      - pkg: apache
+    - watch_in:
+      - service: apache
+
 {% elif grains['os_family']=="FreeBSD" %}
 
 include:


### PR DESCRIPTION
When using the mod_ssl state on Red Hat family systems the httpd
server will currently not start.

This is due to duplicate Listen directives provided in the
ssl.conf file shipped with the mod_ssl rpm package and the directives
configured by saltstack.

The easy solution is to just ensure the rpm shipped mod_ssl is removed.