### PR TITLE
Restart (if needed) before reload

### DIFF
--- a/apache/init.sls
+++ b/apache/init.sls
@@ -15,6 +15,9 @@ apache:
   service.running:
     - name: {{ apache.service }}
     - enable: True
+    - require:
+      - module: apache-restart
+      - module: apache-reload
 
 # The following states are inert by default and can be used by other states to
 # trigger a restart or reload as needed.
@@ -22,6 +25,8 @@ apache-reload:
   module.wait:
     - name: service.reload
     - m_name: {{ apache.service }}
+    - require:
+      - module: apache-restart
 
 apache-restart:
   module.wait:


### PR DESCRIPTION
Some configuration changes only take effect after a restart of the service. When the module 'apache-reload' is triggered too early, it fails which results in a false-negative result of the Salt run.

In order to fix that 'apache-restart' and the service definition itself are put before 'apache-reload'. Reload should always succeed if restart did.

Tested on Debian 9.5.