### PR TITLE
add server_status state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,6 +198,11 @@ of interfaces to bind to. For example, to bind both IPv4 and IPv6:
 
 Configures Apache's security.conf options by reassinging them using data from Pillar.
 
+``apache.server_status``
+--------------------------
+
+Configures Apache's server_status handler for localhost
+
 ``apache.debian_full``
 ----------------------
 

--- a/apache/files/Suse/apache-2.4.config.jinja
+++ b/apache/files/Suse/apache-2.4.config.jinja
@@ -165,7 +165,7 @@ Include /etc/apache2/ssl-global.conf
 
 {% if salt['pillar.get']('apache:mod_ssl:manage_tls_defaults', False) -%}
 Include /etc/apache24/conf.d/tls-defaults.conf
-{%- %}
+{%- endif %}
 
 # global (server-wide) protocol configuration, that is not specific
 # to any virtual host

--- a/apache/files/server-status.conf.jinja
+++ b/apache/files/server-status.conf.jinja
@@ -1,0 +1,10 @@
+<Location "/server-status">
+    SetHandler server-status
+{%- if apache.version == '2.4' %}
+    Require local
+{%- elif apache.version == '2.2' %}
+    Order deny,allow
+    Deny from all
+    Allow from localhost
+{%- endif %}
+</Location>

--- a/apache/server_status.sls
+++ b/apache/server_status.sls
@@ -1,0 +1,18 @@
+{% from "apache/map.jinja" import apache with context %}
+
+include:
+  - apache
+  - apache.config
+
+{{apache.confdir}}/server-status{{apache.confext}}:
+  file.managed:
+    - source: salt://apache/files/server-status.conf.jinja
+    - template: jinja
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache


### PR DESCRIPTION
**Summary of Changes**
 * New state server_status 
   - made in 2.2 and 2.4 ready via jinja
   - auto included via apache.confdir.

Could be improved with more pillar variables on who's allowed to view /server-status

cherry picked from https://github.com/saltstack-formulas/apache-formula/pull/135