### PR TITLE
Fix wrong yaml parsing

### DIFF
--- a/apache/config.sls
+++ b/apache/config.sls
@@ -29,7 +29,7 @@ include:
       - module: apache-reload
       - service: apache
     - context:
-      apache: {{ apache }}
+      apache: {{ apache | json }}
 
 {{ apache.vhostdir }}:
   file.directory:
@@ -72,7 +72,7 @@ include:
       - module: apache-reload
       - service: apache
     - context:
-      apache: {{ apache }}
+      apache: {{ apache | json }}
 
 {% endif %}
 
@@ -104,7 +104,7 @@ include:
       - module: apache-reload
       - service: apache
     - context:
-      apache: {{ apache }}
+      apache: {{ apache | json }}
 {% endif %}
 
 {% if grains['os_family']=="FreeBSD" %}
@@ -136,5 +136,5 @@ include:
       - module: apache-reload
       - service: apache
     - context:
-      apache: {{ apache }}
+      apache: {{ apache | json }}
 {% endif %}


### PR DESCRIPTION
Due to [this SaltStack changes to use unicode strings](https://github.com/saltstack/salt/issues/49724#issuecomment-423261557), the use of `sites:<vhostname>:Formula_Append` to manage vhosts with [apache/vhosts/standard.sls](https://github.com/saltstack-formulas/apache-formula/blob/master/apache/vhosts/standard.sls) introduces parsing errors of the pillar when applying [apache/config.sls](https://github.com/saltstack-formulas/apache-formula/blob/master/apache/config.sls)

```
testhost.com:
    Data failed to compile:
----------
    Rendering SLS 'base:apache.config' failed: while parsing a flow mapping
  in "<unicode string>", line 32, column 798:
     ... t.com'}, 'testsite': {'AcceptPathInfo': 'On', 'Server ... 
                              ^
expected ',' or '}', but got '<scalar>'
  in "<unicode string>", line 32, column 1551:
     ... default\n    # To re-enable it\'s recommended to enable access t ... 
```
Applied the solution documented [here](https://github.com/saltstack/salt/issues/49724#issuecomment-423311794) and [here](https://github.com/saltstack/salt/pull/49731/files) and now it works again.

 - Tested on Debian / CentOS
