### PR TITLE
Fix certificate/key/chain file's group ownerships on BSD Unix

### DIFF
--- a/apache/certificates.sls
+++ b/apache/certificates.sls
@@ -14,7 +14,11 @@ apache_cert_config_{{ site }}_key_file:
     - makedirs: True
     - mode: 600
     - user: root
+{% if grains['os_family'].endswith('BSD') %}
+    - group: wheel
+{% else %}
     - group: root
+{% endif %}
     - watch_in:
       - module: apache-reload
     - require_in:
@@ -32,7 +36,11 @@ apache_cert_config_{{ site }}_cert_file:
     - makedirs: True
     - mode: 600
     - user: root
+{% if grains['os_family'].endswith('BSD') %}
+    - group: wheel
+{% else %}
     - group: root
+{% endif %}
     - watch_in:
       - module: apache-reload
     - require_in:
@@ -50,7 +58,11 @@ apache_cert_config_{{ site }}_bundle_file:
     - makedirs: True
     - mode: 600
     - user: root
+{% if grains['os_family'].endswith('BSD') %}
+    - group: wheel
+{% else %}
     - group: root
+{% endif %}
     - watch_in:
       - module: apache-reload
     - require_in:


### PR DESCRIPTION
The name for GID 0 is different on BSD Unix.

**Summary of Changes**
 * Added three os_family checks; if they match `*BSD`, the states use the wheel group instead of root.

**Testing**
 - Tested on FreeBSD 11.2-RELEASE
 - Tested on CentOS 7.6.1810
