### PR TITLE
Fix mod_remoteip for Red Hat family OS

### DIFF
--- a/apache/files/RedHat/conf.modules.d/remoteip.conf.jinja
+++ b/apache/files/RedHat/conf.modules.d/remoteip.conf.jinja
@@ -1,0 +1,6 @@
+# managed by saltstack
+
+RemoteIPHeader {{ salt['pillar.get']('apache:mod_remoteip:RemoteIPHeader', 'X-Forwarded-For') }}
+{%- for trusted_proxy in salt['pillar.get']('apache:mod_remoteip:RemoteIPTrustedProxy', []) %}
+RemoteIPTrustedProxy {{ trusted_proxy }}
+{%- endfor %}

--- a/apache/mod_remoteip.sls
+++ b/apache/mod_remoteip.sls
@@ -54,7 +54,7 @@ include:
   file.managed:
     - template: jinja
     - source:
-      - salt://apache/files/{{ salt['grains.get']('os_family') }}/remoteip.conf.jinja
+      - salt://apache/files/{{ salt['grains.get']('os_family') }}/conf.modules.d/remoteip.conf.jinja
     - require:
       - pkg: apache
     - watch_in:


### PR DESCRIPTION
The source template was missing for RH based systems, only the Debian
file was packaged.

Fix this.