### PR TITLE
Allow override of default_charset.

### DIFF
--- a/apache/files/RedHat/apache-2.2.config.jinja
+++ b/apache/files/RedHat/apache-2.2.config.jinja
@@ -387,7 +387,11 @@ LogLevel warn
 # in HTML content to override this choice, comment out this
 # directive:
 #
-AddDefaultCharset UTF-8
+{%- if apache.get('default_charset', False) is none %}
+# AddDefaultCharset UTF-8
+{%- else %}
+AddDefaultCharset {{ apache.get('default_charset', 'UTF-8') }}
+{%- endif %}
 
 <IfModule mime_magic_module>
     #

--- a/apache/files/RedHat/apache-2.4.config.jinja
+++ b/apache/files/RedHat/apache-2.4.config.jinja
@@ -348,7 +348,11 @@ LogLevel warn
 # in HTML content to override this choice, comment out this
 # directive:
 #
-AddDefaultCharset {{ apache.default_charset }}
+{%- if apache.get('default_charset', False) is none %}
+# AddDefaultCharset UTF-8
+{%- else %}
+AddDefaultCharset {{ apache.get('default_charset', 'UTF-8') }}
+{%- endif %}
 
 <IfModule mime_magic_module>
     #


### PR DESCRIPTION
The current Red Hat config allows to set DefaultCharset to a value.
In certain situations it is necessary to leave it unconfigured thouguh.

Make the content optional, if the value of apache.default_charset is None,
the item is skipped. Otherwise it defaults to UTF-8.

Drive-By: Make the charset also configurable on 2.2 and not just 2.4 as is currently the case.