### PR TITLE
Update mod_ssl package variable to prevent clashes

### DIFF
--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -31,7 +31,7 @@ a2enmod mod_ssl:
 
 mod_ssl:
   pkg.installed:
-    - name: {{ apache.mod_ssl }}
+    - name: {{ apache.mod_ssl_pkg }}
     - require:
       - pkg: apache
     - watch_in:

--- a/apache/osfamilymap.yaml
+++ b/apache/osfamilymap.yaml
@@ -35,7 +35,7 @@ RedHat:
   group: apache
   configfile: /etc/httpd/conf/httpd.conf
 
-  mod_ssl: mod_ssl
+  mod_ssl_pkg: mod_ssl
   mod_wsgi: mod_wsgi
   conf_mod_wsgi: /etc/httpd/conf.d/wsgi.conf
   mod_php5: php

--- a/pillar.example
+++ b/pillar.example
@@ -20,6 +20,9 @@ apache:
     # apache version (generally '2.2' or '2.4')
     version: '2.2'
 
+    # mod_ssl package name
+    mod_ssl_pkg: mod_ssl
+
     # ``apache.mod_wsgi`` formula additional configuration:
     mod_wsgi: mod_wsgi
 


### PR DESCRIPTION
The mod_ssl package name could be overridden in apache:lookup:mod_ssl.
Due to the way lookup keys are merged into the main apache dictionary,
the package name clashed with the mod_ssl configuration defined under
apache:mod_ssl.

Fix that by renaming the mod_ssl package variable to mod_ssl_pkg.

Drive-By: Add mod_ssl_pkg to the pillar.example file.

**Summary of Changes**
 * Issue summary 
 - Indented line 1
 - Indented line 2
**Testing**
 - Ran `make`
 - Tested in Vagrant
 - Tested on OS 
