### PR TITLE
Patch upload progress

### DIFF
--- a/apache/mod_upload_progress.sls
+++ b/apache/mod_upload_progress.sls
@@ -1,0 +1,22 @@
+{% from "apache/map.jinja" import apache with context %}
+
+{% if grains['os_family']=="Debian" %}
+include:
+  - apache
+
+libapache2-mod-upload-progress:
+  pkg.installed
+
+a2enmod upload_progress:
+  cmd.run:
+    - unless: ls /etc/apache2/mods-enabled/upload_progress.load
+    - order: 255
+    - require:
+      - pkg: libapache2-mod-upload-progress
+    - watch_in:
+      - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
+{% endif %}


### PR DESCRIPTION
It adds state for install upload progress module in debian.

It includes changes from #159, with suggestion to avoid keeping a list of existing mod states