### PR TITLE
fix server_status state

### DIFF
--- a/apache/server_status.sls
+++ b/apache/server_status.sls
@@ -8,6 +8,8 @@ include:
   file.managed:
     - source: salt://apache/files/server-status.conf.jinja
     - template: jinja
+    - context:
+        apache: {{ apache | json }}
     - require:
       - pkg: apache
     - watch_in:


### PR DESCRIPTION
apache/files/server-status.conf.jinja uses apache dict, but it wasn't added to context