### PR TITLE
generate remoteip conf before a2enconf

### DIFF
--- a/apache/mod_remoteip.sls
+++ b/apache/mod_remoteip.sls
@@ -42,6 +42,7 @@ a2enconf remoteip:
       - module: apache-restart
       - module: apache-reload
       - service: apache
+      - cmd: a2enconf remoteip
 {% endif %}
 
 


### PR DESCRIPTION
If I enable remoteip, I had to run state.highstate twice, first run fails to enable config and then generate config, next time it enables config and restart apache. This PR fixes it, so file is required before running a2enconf

```
----------
          ID: a2enconf remoteip
    Function: cmd.run
      Result: False
     Comment: Command "a2enconf remoteip" run
     Started: 13:06:22.954149
    Duration: 35.511 ms
     Changes:   
              ----------
              pid:
                  2951
              retcode:
                  1
              stderr:
                  ERROR: Conf remoteip does not exist!
              stdout:
----------
          ID: /etc/apache2/conf-available/remoteip.conf
    Function: file.managed
      Result: True
     Comment: File /etc/apache2/conf-available/remoteip.conf updated
     Started: 13:06:24.022971
    Duration: 22.452 ms
     Changes:   
              ----------                                                                                                                                                                                            
              diff:
                  New file
              mode:
                  0644
