### PR TITLE
fix(server-status): enable module in debian if `server_status_require…

### DIFF
--- a/apache/files/server-status.conf.jinja
+++ b/apache/files/server-status.conf.jinja
@@ -1,3 +1,7 @@
+########################################################################
+# File managed by Salt at <{{ source }}>.
+# Your changes will be overwritten.
+########################################################################
 <Location "/server-status">
     SetHandler server-status
 {%- if apache.version == '2.4' %}

--- a/apache/server_status.sls
+++ b/apache/server_status.sls
@@ -19,16 +19,10 @@ include:
       - module: apache-reload
       - service: apache
 
-{% if grains['os_family']=="Debian" %}
-a2endisconf server-status:
+{%- if grains['os_family'] == "Debian" %}
+a2enconf server-status:
   cmd.run:
-{%   if apache.get('server_status_require') is defined %}
-    - name: a2enconf server-status
-    - unless: test -L /etc/apache2/conf-enabled/server-status.conf
-{%   else %}
-    - name: a2disconf server-status
-    - onlyif: test -L /etc/apache2/conf-enabled/server-status.conf
-{%   endif %}
+    - unless: 'test -L /etc/apache2/conf-enabled/server-status.conf'
     - order: 225
     - require:
       - pkg: apache

--- a/apache/server_status.sls
+++ b/apache/server_status.sls
@@ -18,3 +18,25 @@ include:
       - module: apache-restart
       - module: apache-reload
       - service: apache
+
+{% if grains['os_family']=="Debian" %}
+a2endisconf server-status:
+  cmd.run:
+{%   if apache.get('server_status_require') is defined %}
+    - name: a2enconf server-status
+    - unless: test -L /etc/apache2/conf-enabled/server-status.conf
+{%   else %}
+    - name: a2disconf server-status
+    - onlyif: test -L /etc/apache2/conf-enabled/server-status.conf
+{%   endif %}
+    - order: 225
+    - require:
+      - pkg: apache
+      - file: {{ apache.confdir }}/server-status.conf
+    - watch_in:
+      - module: apache-restart
+    - require_in:
+      - module: apache-restart
+      - module: apache-reload
+      - service: apache
+{% endif %}

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -157,7 +157,7 @@ suites:
         base:
           '*':
             - apache
-            - apache.mod_security
+            - apache.config
       pillars:
         top.sls:
           base:
@@ -168,3 +168,21 @@ suites:
     verifier:
       inspec_tests:
         - path: test/integration/default
+  - name: modules
+    provisioner:
+      state_top:
+        base:
+          '*':
+            - apache
+            - apache.mod_security
+            - apache.server_status
+      pillars:
+        top.sls:
+          base:
+            '*':
+              - apache
+      pillars_from_files:
+        apache.sls: test/salt/pillar/modules.sls
+    verifier:
+      inspec_tests:
+        - path: test/integration/modules

--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -3,7 +3,19 @@
 control 'apache configuration' do
   title 'should match desired lines'
 
-  describe file('/etc/apache2/apache2.conf') do
+  config_file =
+    case platform[:family]
+    when 'debian'
+      '/etc/apache2/apache2.conf'
+    when 'redhat', 'fedora'
+      '/etc/httpd/conf/httpd.conf'
+    when 'suse'
+      '/etc/apache2/httpd.conf'
+    # `linux` here is sufficient for `arch`
+    when 'linux'
+      '/etc/httpd/conf/httpd.conf'
+    end
+  describe file(config_file) do
     it { should be_file }
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
@@ -13,5 +25,15 @@ control 'apache configuration' do
         'This file is managed by Salt! Do not edit by hand!'
       )
     end
+  end
+end
+control 'apache configuration' do
+  title 'should be valid'
+
+  describe command('apachectl -t') do
+    its('stdout') { should eq '' }
+    its('stderr') { should include 'Syntax OK' }
+
+    its('exit_status') { should eq 0 }
   end
 end

--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+control 'apache configuration' do
+  title 'should match desired lines'
+
+  describe file('/etc/apache2/apache2.conf') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    its('mode') { should cmp '0644' }
+    its('content') do
+      should include(
+        'This file is managed by Salt! Do not edit by hand!'
+      )
+    end
+  end
+end

--- a/test/integration/default/controls/packages_spec.rb
+++ b/test/integration/default/controls/packages_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Overide by OS
+package_name = 'bash'
+package_name = 'cronie' if (os[:name] == 'centos') && os[:release].start_with?('6')
+
+control 'apache package' do
+  title 'should be installed'
+
+  package_name =
+    case platform[:family]
+    when 'debian', 'suse'
+        'apache2'
+    when 'redhat', 'fedora'
+        'httpd'
+    when 'arch'
+        'apache'
+    end
+
+  describe package(package_name) do
+    it { should be_installed }
+  end
+end

--- a/test/integration/default/controls/packages_spec.rb
+++ b/test/integration/default/controls/packages_spec.rb
@@ -1,20 +1,17 @@
 # frozen_string_literal: true
 
-# Overide by OS
-package_name = 'bash'
-package_name = 'cronie' if (os[:name] == 'centos') && os[:release].start_with?('6')
-
 control 'apache package' do
   title 'should be installed'
 
   package_name =
     case platform[:family]
     when 'debian', 'suse'
-        'apache2'
+      'apache2'
     when 'redhat', 'fedora'
-        'httpd'
-    when 'arch'
-        'apache'
+      'httpd'
+    # `linux` here is sufficient for `arch`
+    when 'linux'
+      'apache'
     end
 
   describe package(package_name) do

--- a/test/integration/default/controls/services_spec.rb
+++ b/test/integration/default/controls/services_spec.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-# Overide by OS
-service_name = 'apache2'
-service_name = 'httpd' if (os[:name] == 'centos')
-
 control 'apache service' do
   impact 0.5
   title 'should be running and enabled'
+
+  service_name =
+    case platform[:family]
+    when 'debian', 'suse'
+      'apache2'
+    when 'redhat', 'fedora', 'linux'
+      'httpd'
+    end
 
   describe service(service_name) do
     it { should be_enabled }

--- a/test/integration/default/controls/services_spec.rb
+++ b/test/integration/default/controls/services_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Overide by OS
+service_name = 'apache2'
+service_name = 'httpd' if (os[:name] == 'centos')
+
+control 'apache service' do
+  impact 0.5
+  title 'should be running and enabled'
+
+  describe service(service_name) do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end

--- a/test/integration/modules/README.md
+++ b/test/integration/modules/README.md
@@ -1,0 +1,50 @@
+# InSpec Profile: `modules`
+
+This shows the implementation of the `modules` InSpec [profile](https://github.com/inspec/inspec/blob/master/docs/profiles.md).
+
+## Verify a profile
+
+InSpec ships with built-in features to verify a profile structure.
+
+```bash
+$ inspec check modules
+Summary
+-------
+Location: modules
+Profile: profile
+Controls: 4
+Timestamp: 2019-06-24T23:09:01+00:00
+Valid: true
+
+Errors
+------
+
+Warnings
+--------
+```
+
+## Execute a profile
+
+To run all **supported** controls on a local machine use `inspec exec /path/to/profile`.
+
+```bash
+$ inspec exec modules
+..
+
+Finished in 0.0025 seconds (files took 0.12449 seconds to load)
+8 examples, 0 failures
+```
+
+## Execute a specific control from a profile
+
+To run one control from the profile use `inspec exec /path/to/profile --controls name`.
+
+```bash
+$ inspec exec modules --controls package
+.
+
+Finished in 0.0025 seconds (files took 0.12449 seconds to load)
+1 examples, 0 failures
+```
+
+See an [example control here](https://github.com/inspec/inspec/blob/master/examples/profile/controls/example.rb).

--- a/test/integration/modules/controls/config_spec.rb
+++ b/test/integration/modules/controls/config_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+control 'apache configuration' do
+  title 'should be valid'
+
+  describe command('apachectl -t') do
+    its('stdout') { should eq '' }
+    its('stderr') { should include 'Syntax OK' }
+
+    its('exit_status') { should eq 0 }
+  end
+end

--- a/test/integration/modules/controls/mod_security_spec.rb
+++ b/test/integration/modules/controls/mod_security_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-control 'Apache mod_security configuration' do
+control 'apache mod_security configuration' do
   title 'should match desired lines'
 
   modspec_file =

--- a/test/integration/modules/controls/mod_security_spec.rb
+++ b/test/integration/modules/controls/mod_security_spec.rb
@@ -9,6 +9,8 @@ control 'apache mod_security configuration' do
       '/etc/httpd/conf.d/mod_security.conf'
     when 'debian'
       '/etc/modsecurity/modsecurity.conf-recommended'
+    when 'suse'
+      '/etc/apache2/conf.d/mod_security2.conf'
     end
 
   describe file(modspec_file) do

--- a/test/integration/modules/controls/packages_spec.rb
+++ b/test/integration/modules/controls/packages_spec.rb
@@ -5,12 +5,12 @@ control 'apache mod_security package' do
 
   package_name =
     case platform[:family]
-    when 'debian', 'suse'
-        'libapache2-mod-security2'
+    when 'debian'
+      'libapache2-mod-security2'
     when 'redhat', 'fedora'
-        'mod_security'
+      'mod_security'
     when 'suse'
-        'apache2-mod_security2'
+      'apache2-mod_security2'
     end
 
   describe package(package_name) do

--- a/test/integration/modules/controls/packages_spec.rb
+++ b/test/integration/modules/controls/packages_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+control 'apache mod_security package' do
+  title 'should be installed'
+
+  package_name =
+    case platform[:family]
+    when 'debian', 'suse'
+        'libapache2-mod-security2'
+    when 'redhat', 'fedora'
+        'mod_security'
+    when 'suse'
+        'apache2-mod_security2'
+    end
+
+  describe package(package_name) do
+    it { should be_installed }
+  end
+end

--- a/test/integration/modules/controls/server_status_spec.rb
+++ b/test/integration/modules/controls/server_status_spec.rb
@@ -3,14 +3,14 @@
 control 'apache server_status configuration' do
   title 'should match desired lines'
 
-  server_status_stanza = <<-SS_STANZA
-<Location "/server-status">
-    SetHandler server-status
-    Require local
-    Require host foo.example.com
-    Require ip 10.8.8.0/24
-</Location>
-SS_STANZA
+  server_status_stanza = <<~SS_STANZA
+    <Location "/server-status">
+        SetHandler server-status
+        Require local
+        Require host foo.example.com
+        Require ip 10.8.8.0/24
+    </Location>
+  SS_STANZA
 
   confdir =
     case platform[:family]
@@ -20,7 +20,8 @@ SS_STANZA
       '/etc/httpd/conf.d'
     when 'suse'
       '/etc/apache2/conf.d'
-    when 'arch'
+    # `linux` here is sufficient for `arch`
+    when 'linux'
       '/etc/httpd/conf/extra'
     end
 

--- a/test/integration/modules/controls/server_status_spec.rb
+++ b/test/integration/modules/controls/server_status_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+control 'apache server_status configuration' do
+  title 'should match desired lines'
+
+  server_status_stanza = <<-SS_STANZA
+<Location "/server-status">
+    SetHandler server-status
+    Require local
+    Require host foo.example.com
+    Require ip 10.8.8.0/24
+</Location>
+SS_STANZA
+
+  confdir =
+    case platform[:family]
+    when 'debian'
+      '/etc/apache2/conf-available'
+    when 'redhat', 'fedora'
+      '/etc/httpd/conf.d'
+    when 'suse'
+      '/etc/apache2/conf.d'
+    when 'arch'
+      '/etc/httpd/conf/extra'
+    end
+
+  describe file("#{confdir}/server-status.conf") do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    its('mode') { should cmp '0644' }
+    its('content') { should include '# File managed by Salt' }
+    its('content') { should include server_status_stanza }
+  end
+end

--- a/test/integration/modules/controls/services_spec.rb
+++ b/test/integration/modules/controls/services_spec.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-# Overide by OS
-service_name = 'apache2'
-service_name = 'httpd' if (os[:name] == 'centos')
-
 control 'apache service' do
   impact 0.5
   title 'should be running and enabled'
+
+  service_name =
+    case platform[:family]
+    when 'debian', 'suse'
+      'apache2'
+    when 'redhat', 'fedora', 'linux'
+      'httpd'
+    end
 
   describe service(service_name) do
     it { should be_enabled }

--- a/test/integration/modules/controls/services_spec.rb
+++ b/test/integration/modules/controls/services_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Overide by OS
+service_name = 'apache2'
+service_name = 'httpd' if (os[:name] == 'centos')
+
+control 'apache service' do
+  impact 0.5
+  title 'should be running and enabled'
+
+  describe service(service_name) do
+    it { should be_enabled }
+    it { should_not be_running }
+  end
+end

--- a/test/integration/modules/inspec.yml
+++ b/test/integration/modules/inspec.yml
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+name: modules
+title: apache formula
+maintainer: SaltStack Formulas
+license: Apache-2.0
+summary: Verify that the apache formula manages modules correctly
+supports:
+  - platform-name: debian
+  - platform-name: ubuntu
+  - platform-name: centos
+  - platform-name: fedora
+  - platform-name: opensuse
+  - platform-name: suse
+  - platform-name: freebsd
+  - platform-name: amazon
+  - platform-name: arch

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -1,17 +1,3 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 ---
-apache:
-  manage_service_states: false
-  mod_security:
-    crs_install: true
-    manage_config: true
-    sec_rule_engine: 'On'
-    sec_request_body_access: 'On'
-    sec_request_body_limit: '14000000'
-    sec_request_body_no_files_limit: '114002'
-    sec_request_body_in_memory_limit: '114002'
-    sec_request_body_limit_action: 'Reject'
-    sec_pcre_match_limit: '15000'
-    sec_pcre_match_limit_recursion: '15000'
-    sec_debug_log_level: '3'

--- a/test/salt/pillar/modules.sls
+++ b/test/salt/pillar/modules.sls
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+apache:
+  manage_service_states: false
+  mod_security:
+    crs_install: true
+    manage_config: true
+    sec_rule_engine: 'On'
+    sec_request_body_access: 'On'
+    sec_request_body_limit: '14000000'
+    sec_request_body_no_files_limit: '114002'
+    sec_request_body_in_memory_limit: '114002'
+    sec_request_body_limit_action: 'Reject'
+    sec_pcre_match_limit: '15000'
+    sec_pcre_match_limit_recursion: '15000'
+    sec_debug_log_level: '3'
+  server_status_require:
+    ip:
+      - 10.8.8.0/24
+    host:
+      - foo.example.com


### PR DESCRIPTION
…` is set

<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

`server-status` management was added to the formula a while ago (a3c0022d), but was not for Debian. This PR adds this.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


