### PR TITLE
feat: Add support for ScriptAlias in standard vhost

### DIFF
--- a/apache/vhosts/standard.tmpl
+++ b/apache/vhosts/standard.tmpl
@@ -78,6 +78,10 @@
     Alias {{ loc }} {{ path }}
     {%- endfor %}
 
+    {%- for loc, path in site.get('ScriptAlias', {}).items() %}
+    ScriptAlias {{ loc }} {{ path }}
+    {%- endfor %}
+
     {%- for path, dir in site.get('Directory', {}).items() -%}
     {%- set dvals = {
         'Options': dir.get('Options', vals.Directory.Options),

--- a/pillar.example
+++ b/pillar.example
@@ -284,6 +284,9 @@ apache:
       Alias:
         /docs: /usr/share/docs
 
+      ScriptAlias:
+        /cgi-bin/: /var/www/cgi-bin/
+
       Formula_Append: |
         Additional config as a
         multi-line string here


### PR DESCRIPTION
The standard vhost currently handles a regular Alias configuration
statement, but not the related ScriptAlias.
Add this.
