### PR TITLE
Do not pass full apache context to vhost templates.

### DIFF
--- a/apache/config/vhosts/proxy.tmpl
+++ b/apache/config/vhosts/proxy.tmpl
@@ -81,7 +81,7 @@
         'Dav': loc.get('Dav', False),
     } %}
     <Location "{{ path }}">
-      {%- if apache.version == '2.4' %}
+      {%- if map.version == '2.4' %}
       {% if lvals.get('Require') != False %}Require {{ lvals.Require }}{% endif %}
       {%- else %}
       {% if lvals.get('Order') != False %}Order {{ lvals.Order }}{% endif %}
@@ -98,7 +98,7 @@
         'Dav': locmat.get('Dav', False),
     } %}
     <LocationMatch "{{ regpath }}">
-      {%- if apache.version == '2.4' %}
+      {%- if map.version == '2.4' %}
       {% if lmvals.get('Require') != False %}Require {{ lmvals.Require }}{% endif %}
       {%- else %}
       {% if lmvals.get('Order') != False %}Order {{ lmvals.Order }}{% endif %}

--- a/apache/config/vhosts/standard.sls
+++ b/apache/config/vhosts/standard.sls
@@ -5,6 +5,10 @@
 {%- set sls_package_install = tplroot ~ '.package.install' %}
 {%- set sls_service_running = tplroot ~ '.service.running' %}
 {%- from tplroot ~ "/map.jinja" import apache with context %}
+{#- The apache variable can grow _very_ large, especially the sites subkey.
+    Create a trimmed copy with config variables. #}
+{%- set map = apache %}
+{%- do map.pop('sites', None) %}
 
 include:
   - {{ sls_package_install }}
@@ -20,10 +24,9 @@ apache-config-vhosts-standard-{{ id }}:
     - template: {{ apache.get('template_engine', 'jinja') }}
     - makedirs: True
     - context:
-      apache: {{ apache|json }}
-      id: {{ id|json }}
-      site: {{ site|json }}
-      map: {{ apache|json }}
+        id: {{ id|json }}
+        site: {{ site|json }}
+        map: {{ map|json }}
     - require:
       - pkg: apache-package-install-pkg-installed
     - watch_in:


### PR DESCRIPTION
The full apache context variable can grow quite large if using multiple
vhosts with SSL certificates.
With 200 sites the apache variable is being rendered 200 times which resuls
in observed renderer output of about 950MB...

state.apply will result with MemoryErrors in such cases.

This PR modifies the templating code to _only_ use a per site context
and pass a trimmed down copy of the apache context instead of the full.

Drive-By: Correct indentation for context variables.
Drive-By: Remove duplicate map/apache functionality. Only use map.
