### PR TITLE
 fix(apache.service.running): prevent recursive requisite

### DIFF
--- a/apache/config/file.sls
+++ b/apache/config/file.sls
@@ -19,7 +19,7 @@ apache-config-file-directory-logdir:
     - makedirs: True
     - require:
       - sls: {{ sls_package_install }}
-    - require_in:
+    - watch_in:
       - service: apache-service-running
 
 apache-config-file-directory-vhostdir:
@@ -28,7 +28,7 @@ apache-config-file-directory-vhostdir:
     - makedirs: True
     - require:
       - sls: {{ sls_package_install }}
-    - require_in:
+    - watch_in:
       - service: apache-service-running
 
 apache-config-file-directory-moddir:
@@ -37,7 +37,7 @@ apache-config-file-directory-moddir:
     - makedirs: True
     - require:
       - sls: {{ sls_package_install }}
-    - require_in:
+    - watch_in:
       - service: apache-service-running
 
     {%- if apache.davlockdbdir %}
@@ -53,7 +53,7 @@ apache-config-file-directory-davlockdbdir:
       - group
     - require:
       - sls: {{ sls_package_install }}
-    - require_in:
+    - watch_in:
       - service: apache-service-running
 
     {%- endif %}
@@ -65,7 +65,7 @@ apache-config-file-directory-sites-enabled:
     - makedirs: True
     - require:
       - sls: {{ sls_package_install }}
-    - require_in:
+    - watch_in:
       - service: apache-service-running
 
     {%- endif %}
@@ -77,7 +77,7 @@ apache-config-file-directory-conf-enabled:
     - makedirs: True
     - require:
       - sls: {{ sls_package_install }}
-    - require_in:
+    - watch_in:
       - service: apache-service-running
 
     {%- endif %}
@@ -111,7 +111,7 @@ apache-config-file-managed-{{ grains.os }}-env:
     - template: {{ apache.get('template_engine', 'jinja') }}
     - context:
       apache: {{ apache | json }}
-    - require_in:
+    - watch_in:
       - file: apache-config-file-managed-{{ grains.os }}-ports
 
 apache-config-file-managed-{{ grains.os }}-ports:
@@ -157,7 +157,5 @@ apache-config-file-managed-skip:
     - require:
       - sls: {{ sls_package_install }}
     - watch_in:
-      - module: apache-service-running-restart
-    - require_in:
       - module: apache-service-running-restart
       - service: apache-service-running

--- a/apache/config/file.sls
+++ b/apache/config/file.sls
@@ -97,6 +97,8 @@ apache-config-file-managed:
       - sls: {{ sls_package_install }}
     - context:
         apache: {{ apache | json }}
+    - watch_in:
+      - service: apache-service-running
 
   {%- if grains.os_family in ('Debian', 'FreeBSD') %}
 

--- a/apache/config/modules/install.sls
+++ b/apache/config/modules/install.sls
@@ -41,7 +41,7 @@ apache-config-modules-{{ module }}-enable:
         {%- endif %}
     - order: 225
     - require:
-      - sls: {{ sls_config_file }}
+      - file: apache-config-file-directory-moddir
     - watch_in:
       - module: apache-service-running-restart
     - require_in:

--- a/apache/service/running.sls
+++ b/apache/service/running.sls
@@ -16,8 +16,6 @@ apache-service-running:
   service.running:
     - name: {{ apache.service.name }}
     - enable: True
-    - watch:
-      - sls: {{ sls_config_file }}
     - retry: {{ apache.retry_option|json }}
   cmd.run:
     - names:
@@ -41,10 +39,7 @@ apache-service-running-restart:
     - cmd: {{ apache.custom_reload_command|default('apachectl graceful') }}
     - python_shell: True
          {%- endif %}
-    - watch:
-      - sls: {{ sls_config_file }}
-    - require:
-      - sls: {{ sls_config_file }}
+    - after:
       - service: apache-service-running
 
 apache-service-running-reload:
@@ -57,8 +52,5 @@ apache-service-running-reload:
     - cmd: {{ apache.custom_reload_command|default('apachectl graceful') }}
     - python_shell: True
          {%- endif %}
-    - watch:
-      - sls: {{ sls_config_file }}
-    - require:
-      - sls: {{ sls_config_file }}
+    - after:
       - service: apache-service-running

--- a/apache/service/running.sls
+++ b/apache/service/running.sls
@@ -19,7 +19,7 @@ apache-service-running:
     - retry: {{ apache.retry_option|json }}
   cmd.run:
     - names:
-      - journalctl -xe -u {{ apache.service.name }} || tail -20 /var/log/messages || true
+      - journalctl -n20 -e -u {{ apache.service.name }} || tail -20 /var/log/messages || true
       - (service {{ apache.service.name }} restart && service {{ apache.service.name }} status) || true
       - cat {{ apache.config }}
     - onfail:


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

This fixes the same issue as #388, but slightly more completely.

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

The fixes circular requisite errors when using the formula. Most of the change isn't mine (see the commit authors), but I added some tweaks, hence the new PR.

In terms of how the change works, mostly copying from my comment on #388

- The changes to `apache/config/file.sls are all just `s/require_in/watch_in/`.  AIUI the watch requisite [implies](https://docs.saltproject.io/salt/user-guide/en/latest/topics/requisites.html#the-watch-requisite) the require requisite, so these are required either way, this just means that we restart Apache if they change.
  - Almost all the changes to file.sls are in `file.directory` states. I think if Apache previously crashed, `service.running` would rerun anyway, and it's unlikely that Apache would run but incorrectly without these directories, so I don't see why `watch_in` is needed. OTOH, it's probably harmless.
  - The other one is in OS-dependent config files (the diff looks like deleted lines, because the `require_in` is getting combined with the `watch_in`). This seems like an improvement, though it's hard to see how it would improve a circular dep.
  - (My additional change is to add a `watch_in` for the main config file. This seems like it would be pretty important to getting appropriate config-reloading behavior.)
- The *removed* requisites (which are presumably how you break a loop) are in apache/service/running.sls.
  - The three `apache-service-running*` states lose their `watch` (and usually require, which AIUI is redundant) on `sls: {{ sls_config_file }}`, which AFAICT is just the whole `apache.config.file` from earlier in the PR. Effectively, in combination with the earlier changes, I think this is replacing a broad dependency from the running states on the whole config file sls (in `running.sls`) with narrow dependencies from the running states to *each* of the config file states (in `file.sls`). My guess is that `require: sls: whatever` requires *everything* in that SLS, *including* the includes, and we `include` `{{ sls_service_running}}`, which would make a loop.
  - `-reload` and `-running` lose their `watch`/`require` entirely (there's no consistent `watch_in` for them), but they're `after` the `service: apache-service-running`. I can't find a definition of `after`, but my guess is this functionally means we need `apache-service-running`'s prereqs, which is good enough. (Also these shouldn't run all that much.)
- (I make a similar change in `apache/config/modules/install.sls` to use a finer-grained requisite there (based on [danny-smit](https://github.com/danny-smit)'s patch)

I also reduce the amount of logging dumped to salt when Apache restarts -- the old parameters could really clutter the output, which was very apparent when circular deps meant it kept failing to restart.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


